### PR TITLE
Remove loop from open_connection

### DIFF
--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -173,7 +173,7 @@ class AsyncSatel:
 
         try:
             self._reader, self._writer = await asyncio.open_connection(
-                self._host, self._port, loop=self._loop)
+                self._host, self._port)
             _LOGGER.debug("sucess connecting...")
 
         except Exception as e:


### PR DESCRIPTION
Fix for https://github.com/c-soft/satel_integra/issues/19

It's probably possible to also remove the `loop` reference inside the init function?