### PR TITLE
Synchronises sending commands with Satel responses

### DIFF
--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -281,8 +281,8 @@ class AsyncSatel:
         """Keeps sending commands from the queue and 
            waiting for anwers"""
         while True:
-            await self._command_queue.get()
-            if await self._send_data_internal(self._current_command):
+            data = await self._command_queue.get()
+            if await self._send_data_internal(data):
                 try:
                     await asyncio.wait_for(self._command_status_event.wait(), timeout=10)
                     self._command_status_event.clear()

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -72,7 +72,7 @@ def generate_query(command):
     c = checksum(data)
     data.append(c >> 8)
     data.append(c & 0xFF)
-    data.replace(b'\xFE', b'\xFE\xF0')
+    data = data.replace(b'\xFE', b'\xFE\xF0')
 
     data = bytearray.fromhex("FEFE") + data + bytearray.fromhex("FE0D")
     return data


### PR DESCRIPTION
Synchronises sending commands with Satel responses to avoid dropping commands sent to quickly one after another.
Commands are now not sent directly but rather put in a queue. There is a separate asynchronous task which picks items from the queue, sends them and then waits for the notification before picking another one.
Currently the implementation does not associate commands with responses but that is not a problem for the moment.
I have successfully tested the fix with my own Home Assisstant installation (I'm preparing HA PR as well).