### PR TITLE
Added connection class

### DIFF
--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -1,0 +1,115 @@
+"""Connection management for Satel Integra panel."""
+
+import asyncio
+import logging
+
+from satel_integra.const import FRAME_END
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SatelConnection:
+    """Manages TCP connection and I/O for the Satel Integra panel."""
+
+    def __init__(self, host: str, port: int, reconnection_timeout: int = 15) -> None:
+        self._host = host
+        self._port = port
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+        self.closed = False
+        self._reconnection_timeout = reconnection_timeout
+
+    @property
+    def connected(self) -> bool:
+        """Return True if connected to the panel."""
+        return self._reader is not None and self._writer is not None
+
+    async def connect(self) -> bool:
+        """Establish TCP connection."""
+        if self.closed:
+            _LOGGER.debug("Connection is closed, skipping connection")
+            return False
+
+        _LOGGER.debug("Connecting to Satel Integra at %s:%s...", self._host, self._port)
+        try:
+            self._reader, self._writer = await asyncio.open_connection(
+                self._host, self._port
+            )
+        except Exception as e:
+            _LOGGER.warning("Connection failed: %s", e)
+            self._reader, self._writer = None, None
+            return False
+        else:
+            _LOGGER.info("Connected to Satel Integra.")
+            return True
+
+    async def read_frame(self) -> bytes | None:
+        """Read a raw frame from the panel."""
+        if not self._reader:
+            _LOGGER.warning("Cannot read, not connected.")
+            return None
+
+        try:
+            frame = await self._reader.readuntil(FRAME_END)
+        except Exception as e:
+            _LOGGER.warning("Read failed: %s", e)
+            self._reader = None
+            self._writer = None
+            return None
+        else:
+            _LOGGER.debug("Received raw frame: %s", frame.hex())
+            return frame
+
+    async def send_frame(self, frame: bytes) -> bool:
+        """Send a raw frame to the panel."""
+        if not self._writer:
+            _LOGGER.warning("Cannot send, not connected.")
+            return False
+
+        try:
+            self._writer.write(frame)
+            await self._writer.drain()
+        except Exception as e:
+            _LOGGER.warning("Write failed: %s", e)
+            self._reader = None
+            self._writer = None
+            return False
+        else:
+            _LOGGER.debug("Sent raw frame: %s", frame.hex())
+            return True
+
+    async def ensure_connected(self) -> bool:
+        """Reconnect automatically if disconnected."""
+        if self.connected:
+            return True
+
+        _LOGGER.debug("Not connected, attempting reconnection...")
+        while not self.connected and not self.closed:
+            success = await self.connect()
+            if not success:
+                _LOGGER.warning(
+                    "Reconnect failed, retrying in %ss...", self._reconnection_timeout
+                )
+                await asyncio.sleep(self._reconnection_timeout)
+
+        return self.connected
+
+    async def close(self) -> None:
+        """Close the connection gracefully and clean up."""
+        if self.closed or not self.connected:
+            return  # already closed, avoid duplicate calls
+
+        self.closed = True
+        _LOGGER.debug("Closing connection...")
+
+        if self._writer and not self._writer.is_closing():
+            try:
+                self._writer.close()
+                await self._writer.wait_closed()
+            except Exception as e:
+                _LOGGER.warning("Exception during close: %s", e)
+
+        self._reader = None
+        self._writer = None
+
+        _LOGGER.info("Connection closed cleanly.")

--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -88,7 +88,7 @@ class SatelConnection:
             success = await self.connect()
             if not success:
                 _LOGGER.warning(
-                    "Reconnect failed, retrying in %ss...", self._reconnection_timeout
+                    "Connection failed, retrying in %ss...", self._reconnection_timeout
                 )
                 await asyncio.sleep(self._reconnection_timeout)
 

--- a/satel_integra/const.py
+++ b/satel_integra/const.py
@@ -1,3 +1,3 @@
 """Constants for the Satel Integra integration."""
 
-FRAME_END = bytes([0xFE, 0xFE])
+FRAME_END = bytes([0xFE, 0x0D])

--- a/satel_integra/const.py
+++ b/satel_integra/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Satel Integra integration."""
+
+FRAME_END = bytes([0xFE, 0xFE])

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -7,6 +7,7 @@ import logging
 from enum import Enum, unique
 
 from satel_integra.commands import SatelReadCommand, SatelWriteCommand
+from satel_integra.connection import SatelConnection
 from satel_integra.utils import encode_bitmask_le
 
 _LOGGER = logging.getLogger(__name__)
@@ -117,11 +118,12 @@ class AlarmState(Enum):
 class AsyncSatel:
     """Asynchronous interface to talk to Satel Integra alarm system."""
 
-    def __init__(self, host, port, loop, monitored_zones=[],
-                 monitored_outputs=[], partitions=[]):
+    def __init__(
+        self, host, port, loop, monitored_zones=[], monitored_outputs=[], partitions=[]
+    ):
         """Init the Satel alarm data."""
-        self._host = host
-        self._port = port
+        self._connection = SatelConnection(host, port)
+
         self._loop = loop
         self._monitored_zones = monitored_zones
         self.violated_zones = []
@@ -130,9 +132,6 @@ class AsyncSatel:
         self.partition_states = {}
         self._keep_alive_timeout = 20
         self._reconnection_timeout = 15
-        self._reader = None
-        self._writer = None
-        self.closed = False
         self._alarm_status_callback = None
         self._zone_changed_callback = None
         self._output_changed_callback = None

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -32,7 +32,7 @@ def print_hex(data):
     _LOGGER.debug(hex_msg)
 
 
-def verify_and_strip(resp):
+def verify_and_strip(resp: bytes) -> bytes:
     """Verify checksum and strip header and footer of received frame."""
     if resp[0:2] != b'\xFE\xFE':
         _LOGGER.error("Houston, we got problem:")
@@ -273,24 +273,13 @@ class AsyncSatel:
     #         _LOGGER.warning("Timeout waiting for reponse from Satel!")
     #     return self._command_status
 
-    async def _send_data(self, data):
+    async def _send_data(self, data: bytearray) -> bool:
         _LOGGER.debug("-- Sending data --")
         print_hex(data)
         _LOGGER.debug("-- ------------- --")
         _LOGGER.debug("Sending %d bytes...", len(data))
 
-        if not self._writer:
-            _LOGGER.warning("Ignoring data because we're disconnected!")
-            return
-        try:
-            self._writer.write(data)
-            await self._writer.drain()
-        except Exception as e:
-            _LOGGER.warning(
-                "Exception during sending data: %s.", e)
-            self._writer = None
-            self._reader = None
-            return False
+        return await self._connection.send_frame(data)
 
     async def arm(self, code, partition_list, mode=0):
         """Send arming command to the alarm. Modes allowed: from 0 till 3."""

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -429,25 +429,13 @@ class AsyncSatel:
         _LOGGER.info("Starting monitor_status loop")
 
         while not self.closed:
-            _LOGGER.debug("Iteration... ")
-            while not self.connected:
-                _LOGGER.info("Not connected, re-connecting... ")
-                await self.connect()
-                if not self.connected:
-                    _LOGGER.warning("Not connected, sleeping for 10s... ")
-                    await asyncio.sleep(self._reconnection_timeout)
-                    continue
+            await self._connection.ensure_connected()
+
             await self.start_monitoring()
-            if not self.connected:
-                _LOGGER.warning("Start monitoring failed, sleeping for 10s...")
-                await asyncio.sleep(self._reconnection_timeout)
-                continue
-            while True:
+
+            while self.connected and not self.closed:
                 await self._update_status()
                 _LOGGER.debug("Got status!")
-                if not self.connected:
-                    _LOGGER.info("Got connection broken, reconnecting!")
-                    break
         _LOGGER.info("Closed, quit monitoring.")
 
     # region Connection management

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -131,7 +131,6 @@ class AsyncSatel:
         self.violated_outputs = []
         self.partition_states = {}
         self._keep_alive_timeout = 20
-        self._reconnection_timeout = 15
         self._alarm_status_callback = None
         self._zone_changed_callback = None
         self._output_changed_callback = None

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,170 @@
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from satel_integra.connection import SatelConnection
+
+
+@pytest.mark.asyncio
+async def test_connect_success(monkeypatch):
+    reader, writer = AsyncMock(), AsyncMock()
+    monkeypatch.setattr(
+        asyncio, "open_connection", AsyncMock(return_value=(reader, writer))
+    )
+
+    conn = SatelConnection("localhost", 1234)
+    assert await conn.connect() is True
+    assert conn.connected
+
+
+@pytest.mark.asyncio
+async def test_connect_failure(monkeypatch):
+    monkeypatch.setattr(
+        asyncio, "open_connection", AsyncMock(side_effect=OSError("boom"))
+    )
+    conn = SatelConnection("localhost", 1234)
+    assert await conn.connect() is False
+    assert not conn.connected
+
+
+@pytest.mark.asyncio
+async def test_connect_skipped_when_closed():
+    conn = SatelConnection("localhost", 1234)
+    conn.closed = True
+    assert await conn.connect() is False
+
+
+@pytest.mark.asyncio
+async def test_send_frame_success(monkeypatch):
+    writer = MagicMock()
+    writer.write = MagicMock()
+    writer.drain = AsyncMock()
+
+    conn = SatelConnection("host", 1)
+    conn._writer = writer
+    frame = b"abc"
+    result = await conn.send_frame(frame)
+    assert result
+    writer.write.assert_called_once_with(frame)
+    writer.drain.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_send_frame_not_connected():
+    conn = SatelConnection("h", 1)
+    result = await conn.send_frame(b"x")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_send_frame_failure(monkeypatch):
+    writer = MagicMock()
+    writer.write = MagicMock()
+    writer.drain.side_effect = Exception("fail")
+    conn = SatelConnection("h", 1)
+    conn._writer = writer
+    result = await conn.send_frame(b"x")
+    assert not result
+    assert conn._writer is None
+
+
+@pytest.mark.asyncio
+async def test_read_frame_success(monkeypatch):
+    from satel_integra.const import FRAME_END
+
+    reader = AsyncMock()
+    reader.readuntil.return_value = b"data" + FRAME_END
+    conn = SatelConnection("h", 1)
+    conn._reader = reader
+    frame = await conn.read_frame()
+    assert frame is not None
+    assert frame.endswith(FRAME_END)
+    reader.readuntil.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_read_frame_not_connected():
+    conn = SatelConnection("h", 1)
+    result = await conn.read_frame()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_read_frame_failure(monkeypatch):
+    reader = AsyncMock()
+    reader.readuntil.side_effect = Exception("boom")
+    conn = SatelConnection("h", 1)
+    conn._reader = reader
+    conn._writer = AsyncMock()
+    result = await conn.read_frame()
+    assert result is None
+    assert conn._reader is None
+    assert conn._writer is None
+
+
+@pytest.mark.asyncio
+async def test_read_frame_timeout():
+    conn = SatelConnection("host", 1234)
+    conn._reader = AsyncMock()
+    conn._reader.readuntil.side_effect = asyncio.TimeoutError()
+
+    result = await conn.read_frame()
+    assert result is None
+    assert not conn.connected  # Should disconnect on timeout
+
+
+@pytest.mark.asyncio
+async def test_ensure_connected_already_connected():
+    conn = SatelConnection("h", 1)
+    conn._reader = AsyncMock()
+    conn._writer = AsyncMock()
+    assert await conn.ensure_connected() is True
+
+
+@pytest.mark.asyncio
+async def test_ensure_connected_reconnect(monkeypatch):
+    conn = SatelConnection("h", 1, reconnection_timeout=0)
+    calls = 0
+
+    async def fake_connect():
+        nonlocal calls
+        calls += 1
+        if calls < 2:
+            return False
+        conn._reader, conn._writer = AsyncMock(), AsyncMock()
+        return True
+
+    conn.connect = fake_connect
+    result = await conn.ensure_connected()
+    assert result
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_close_success(monkeypatch):
+    writer = MagicMock()
+    writer.is_closing.return_value = False
+    writer.close = MagicMock()
+    writer.wait_closed = AsyncMock()
+
+    conn = SatelConnection("h", 1)
+    conn._reader, conn._writer = AsyncMock(), writer
+
+    # Verify initial state
+    assert not conn.closed
+    assert conn.connected
+
+    await conn.close()
+
+    assert conn.closed
+    writer.close.assert_called_once()
+    writer.wait_closed.assert_awaited_once()
+
+    assert conn._reader is None
+    assert conn._writer is None
+
+
+@pytest.mark.asyncio
+async def test_close_already_closed():
+    conn = SatelConnection("h", 1)
+    conn.closed = True
+    await conn.close()  # should not raise or call anything


### PR DESCRIPTION
Added separate connection class which handles connection, disconnection, sending and receiving data. This allows for better abstraction as well as testing the connection stuff by itself.

Initially I thought the connection breaking after 25 seconds was due to the reading loop getting stuck if no data is received, but it indeed it just due to the alarm panel breaking the TCP connection when no data is received. I tried setting TCP keepalive settings but those did not help.

In a future PR I'd like to combine the monitoring loop and the keep alive loop, so we only need to start 1 method to start the whole system. In that PR I would also try to look for the best command to use (least amount of bytes transferred), to keep overhead low. We might be use to use the current command to implement a Device in Home Assistant (along with firmware version details).

A change we need to make to the Home Assistant codebase for this one is that `close` function is now async, as it will actually wait for the writer to finish closing.