### PR TITLE
Allow protocol verification during connect

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,8 +1,7 @@
 import asyncio
-from satel_integra import AsyncSatel
-
-
 import logging
+
+from satel_integra import AsyncSatel
 
 
 async def main(host: str, port: int) -> None:

--- a/examples/encryption.py
+++ b/examples/encryption.py
@@ -1,8 +1,7 @@
 import asyncio
-from satel_integra import AsyncSatel
-
-
 import logging
+
+from satel_integra import AsyncSatel
 
 
 async def main(host: str, port: int, integration_key: str) -> None:

--- a/examples/monitoring.py
+++ b/examples/monitoring.py
@@ -1,8 +1,7 @@
 import asyncio
-from satel_integra import AsyncSatel
-
-
 import logging
+
+from satel_integra import AsyncSatel
 
 
 async def main(host: str, port: int, integration_key: str | None = None) -> None:

--- a/satel_integra/commands.py
+++ b/satel_integra/commands.py
@@ -54,6 +54,7 @@ class SatelWriteCommand(SatelBaseCommand):
     OUTPUTS_ON = 0x88
     OUTPUTS_OFF = 0x89
     READ_DEVICE_NAME = 0xEE
+    RTC_AND_STATUS = 0x1A
 
 
 # Write commands that echo themselves back instead of returning RESULT

--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -79,16 +79,20 @@ class SatelConnection:
         if verify_connection:
             _LOGGER.debug("TCP connection established, verifying panel responsiveness")
             if not await self._check_connection():
-                _LOGGER.warning("Panel not responsive or busy.")
+                _LOGGER.warning(
+                    "Connected to the panel, but it is not ready for use. "
+                    "Another client may already be connected, or the panel may "
+                    "still be busy."
+                )
                 await self._close_locked()
                 return False
 
             _LOGGER.debug("TCP connection established, verifying protocol round-trip")
             if not await self._verify_protocol():
                 _LOGGER.warning(
-                    "TCP connection opened but startup protocol verification failed. "
-                    "Disabling this client instance; this commonly indicates an "
-                    "encryption mismatch or invalid integration key."
+                    "Connected to the panel, but startup validation failed. "
+                    "Check that the integration key and encryption settings match "
+                    "the panel configuration."
                 )
                 await self._close_locked()
                 return False
@@ -204,7 +208,9 @@ class SatelConnection:
     async def _verify_protocol(self) -> bool:
         """Verify that the panel accepts protocol frames on this transport."""
         if not self._transport.connected:
-            _LOGGER.warning("Cannot check connection, not connected.")
+            _LOGGER.info(
+                "Skipping protocol verification because the transport is not connected."
+            )
             return False
 
         try:
@@ -215,12 +221,18 @@ class SatelConnection:
                 self._transport.read_frame(), timeout=MESSAGE_RESPONSE_TIMEOUT
             )
         except Exception as exc:
-            _LOGGER.warning("Startup protocol verification failed: %s", exc)
+            _LOGGER.info(
+                "Startup protocol verification failed while sending or reading "
+                "the probe response: %s",
+                exc,
+                exc_info=True,
+            )
             return False
 
         if not raw_response:
-            _LOGGER.warning(
-                "Startup protocol verification failed: no response received from panel."
+            _LOGGER.info(
+                "Startup protocol verification failed: no response received from the "
+                "panel."
             )
             return False
 
@@ -229,7 +241,9 @@ class SatelConnection:
     async def _check_connection(self) -> bool:
         """Check if the connection is valid and the panel is responsive."""
         if not self._transport.connected:
-            _LOGGER.warning("Cannot check connection, not connected.")
+            _LOGGER.info(
+                "Skipping connection check because the transport is not connected."
+            )
             return False
 
         try:
@@ -238,26 +252,29 @@ class SatelConnection:
             )
 
             if data is None:
-                _LOGGER.warning(
-                    "Connection check failed: no initial data could be read."
-                )
+                _LOGGER.info("Connection check failed: no initial data could be read.")
                 return False
 
             # Satel returns a string starting with "Busy" when another client is connected
             if b"Busy" in data:
-                _LOGGER.warning("Panel reports busy (another client is connected).")
+                _LOGGER.info(
+                    "Connection check failed: panel reports busy because another "
+                    "client is connected."
+                )
                 return False
 
             # Log any other data to debug other potential blocking situation
-            _LOGGER.debug("Received data after connect: %s", data)
+            _LOGGER.debug(
+                "Connection check received initial data after connect: %s", data
+            )
 
             # Encrypted panels appear to return opaque bytes immediately when the
             # session is already occupied. A healthy encrypted connection times out
             # here instead.
             if isinstance(self._transport, SatelEncryptedTransport) and data:
-                _LOGGER.warning(
-                    "Encrypted panel returned unexpected initial data; treating "
-                    "connection as busy or unavailable."
+                _LOGGER.info(
+                    "Connection check failed: encrypted panel returned unexpected "
+                    "initial data, so the session is treated as busy or unavailable."
                 )
                 return False
 
@@ -265,7 +282,7 @@ class SatelConnection:
             # Timeout is fine, it means we can actually read data
             pass
         except Exception as exc:
-            _LOGGER.debug("Connection check failed: %s", exc)
+            _LOGGER.debug("Connection check failed: %s", exc, exc_info=True)
             return False
 
         return True

--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -72,7 +72,7 @@ class SatelConnection:
 
         if not await self._transport.connect():
             _LOGGER.warning("Unable to establish TCP connection.")
-            await self._close_locked()
+            await self._close_locked(stop=False)
             return False
 
         if verify_connection:
@@ -83,7 +83,7 @@ class SatelConnection:
                     "Another client may already be connected, or the panel may "
                     "still be busy."
                 )
-                await self._close_locked()
+                await self._close_locked(stop=False)
                 return False
 
             _LOGGER.debug("TCP connection established, verifying protocol round-trip")
@@ -93,7 +93,7 @@ class SatelConnection:
                     "Check that the integration key and encryption settings match "
                     "the panel configuration."
                 )
-                await self._close_locked()
+                await self._close_locked(stop=False)
                 return False
 
         else:
@@ -157,16 +157,18 @@ class SatelConnection:
             )
             await asyncio.sleep(self._reconnection_timeout)
 
-    async def _close_locked(self) -> None:
-        """Close the connection while the connection lock is already held."""
+    async def _close_locked(self, stop: bool = True) -> None:
+        """Close the connection while the lock is already held."""
         if self.stopped:
             return
 
         _LOGGER.debug("Closing connection...")
         await self._transport.close()
-        self._stopped = True
-        self._stopped_event.set()
-        _LOGGER.info("Connection closed cleanly.")
+
+        if stop:
+            self._stopped = True
+            self._stopped_event.set()
+            _LOGGER.debug("Connection closed cleanly.")
 
     async def wait_stopped(self) -> None:
         """Wait until the connection enters its terminal stopped state."""

--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -3,6 +3,9 @@
 import asyncio
 import logging
 
+from satel_integra.commands import SatelWriteCommand
+from satel_integra.const import MESSAGE_RESPONSE_TIMEOUT
+from satel_integra.messages import SatelWriteMessage
 from satel_integra.transport import (
     SatelBaseTransport,
     SatelEncryptedTransport,
@@ -48,7 +51,7 @@ class SatelConnection:
         """Return True if the connection is closed."""
         return self._closed
 
-    async def _connect(self, check_busy: bool = True) -> bool:
+    async def _connect(self, verify_connection: bool = True) -> bool:
         """Establish TCP connection. Must be called with _connection_lock held."""
         if self.closed:
             _LOGGER.debug("Connection is closed, skipping connection")
@@ -63,19 +66,29 @@ class SatelConnection:
         await self._transport.connect()
         if not await self._transport.wait_connected():
             _LOGGER.warning("Unable to establish TCP connection.")
+            await self.close()
             return False
 
-        if check_busy:
-            _LOGGER.debug(
-                "TCP connection established, verifying panel responsiveness..."
-            )
-            if not await self._transport.check_connection():
+        if verify_connection:
+            _LOGGER.debug("TCP connection established, verifying panel responsiveness")
+            if not await self._check_connection():
                 _LOGGER.warning("Panel not responsive or busy.")
-                await self._transport.close()
+                await self.close()
                 return False
+
+            _LOGGER.debug("TCP connection established, verifying protocol round-trip")
+            if not await self._verify_protocol():
+                _LOGGER.warning(
+                    "TCP connection opened but startup protocol verification failed. "
+                    "Disabling this client instance; this commonly indicates an "
+                    "encryption mismatch or invalid integration key."
+                )
+                await self.close()
+                return False
+
         else:
             _LOGGER.debug(
-                "TCP connection established, skipping busy/panel responsiveness check."
+                "TCP connection established, skipping connection health check."
             )
 
         _LOGGER.info("Connected to Satel Integra.")
@@ -89,7 +102,7 @@ class SatelConnection:
         self._had_connection = True
         return True
 
-    async def connect(self, check_busy: bool = True) -> bool:
+    async def connect(self, verify_connection: bool = True) -> bool:
         """Establish TCP connection with a single attempt (no retries).
 
         Acquires lock internally. Suitable for setup validation where a single
@@ -100,7 +113,7 @@ class SatelConnection:
                 return False
             if self.connected:
                 return True
-            return await self._connect(check_busy=check_busy)
+            return await self._connect(verify_connection=verify_connection)
 
     async def read_frame(self) -> bytes | None:
         """Read a raw frame from the panel."""
@@ -122,6 +135,9 @@ class SatelConnection:
             # Double-check after acquiring lock
             if self.connected:
                 return True
+
+            if self.closed:
+                return False
 
             _LOGGER.debug("Not connected, attempting reconnection...")
             success = await self._connect()
@@ -155,4 +171,73 @@ class SatelConnection:
 
         self._reconnected_event.clear()
         await self._reconnected_event.wait()
+        return True
+
+    async def _verify_protocol(self) -> bool:
+        """Verify that the panel accepts protocol frames on this transport."""
+        if not self._transport.connected:
+            _LOGGER.warning("Cannot check connection, not connected.")
+            return False
+
+        try:
+            probe = SatelWriteMessage(SatelWriteCommand.RTC_AND_STATUS)
+
+            await self._transport.send_frame(probe.encode_frame())
+            raw_response = await asyncio.wait_for(
+                self._transport.read_frame(), timeout=MESSAGE_RESPONSE_TIMEOUT
+            )
+        except Exception as exc:
+            _LOGGER.warning("Startup protocol verification failed: %s", exc)
+            return False
+
+        if not raw_response:
+            _LOGGER.warning(
+                "Startup protocol verification failed: no response received from panel."
+            )
+            return False
+
+        return True
+
+    async def _check_connection(self) -> bool:
+        """Check if the connection is valid and the panel is responsive."""
+        if not self._transport.connected:
+            _LOGGER.warning("Cannot check connection, not connected.")
+            return False
+
+        try:
+            data = await asyncio.wait_for(
+                self._transport.read_initial_data(), timeout=0.1
+            )
+
+            if data is None:
+                _LOGGER.warning(
+                    "Connection check failed: no initial data could be read."
+                )
+                return False
+
+            # Satel returns a string starting with "Busy" when another client is connected
+            if b"Busy" in data:
+                _LOGGER.warning("Panel reports busy (another client is connected).")
+                return False
+
+            # Log any other data to debug other potential blocking situation
+            _LOGGER.debug("Received data after connect: %s", data)
+
+            # Encrypted panels appear to return opaque bytes immediately when the
+            # session is already occupied. A healthy encrypted connection times out
+            # here instead.
+            if isinstance(self._transport, SatelEncryptedTransport) and data:
+                _LOGGER.warning(
+                    "Encrypted panel returned unexpected initial data; treating "
+                    "connection as busy or unavailable."
+                )
+                return False
+
+        except asyncio.TimeoutError:
+            # Timeout is fine, it means we can actually read data
+            pass
+        except Exception as exc:
+            _LOGGER.debug("Connection check failed: %s", exc)
+            return False
+
         return True

--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -5,6 +5,7 @@ import logging
 
 from satel_integra.commands import SatelWriteCommand
 from satel_integra.const import MESSAGE_RESPONSE_TIMEOUT
+from satel_integra.exceptions import SatelConnectionStoppedError
 from satel_integra.messages import SatelWriteMessage
 from satel_integra.transport import (
     SatelBaseTransport,
@@ -35,6 +36,7 @@ class SatelConnection:
         )
 
         self._stopped = False
+        self._stopped_event = asyncio.Event()
         self._connection_lock = asyncio.Lock()  # Prevent concurrent connect/close
         self._reconnected_event = (
             asyncio.Event()
@@ -50,6 +52,11 @@ class SatelConnection:
     def stopped(self) -> bool:
         """Return True if the connection is stopped."""
         return self._stopped
+
+    def _assert_not_stopped(self) -> None:
+        """Raise if the connection is in a terminal stopped state."""
+        if self.stopped:
+            raise SatelConnectionStoppedError("Connection is stopped")
 
     async def _connect(self, verify_connection: bool = True) -> bool:
         """Establish TCP connection. Must be called with _connection_lock held."""
@@ -123,34 +130,29 @@ class SatelConnection:
         """Send a raw frame to the panel."""
         return await self._transport.send_frame(frame)
 
-    async def ensure_connected(self) -> bool:
-        """Reconnect automatically if disconnected."""
-        if self.connected:
-            return True
+    async def ensure_connected(self) -> None:
+        """Reconnect automatically until connected or terminally stopped."""
+        while not self.connected:
+            self._assert_not_stopped()
 
-        if self.stopped:
-            return False
+            async with self._connection_lock:
+                # Double-check after acquiring lock
+                if self.connected:
+                    return
 
-        async with self._connection_lock:
-            # Double-check after acquiring lock
-            if self.connected:
-                return True
+                self._assert_not_stopped()
 
-            if self.stopped:
-                return False
+                _LOGGER.debug("Not connected, attempting reconnection...")
+                success = await self._connect()
 
-            _LOGGER.debug("Not connected, attempting reconnection...")
-            success = await self._connect()
-            if not success:
-                if self.stopped:
-                    return False
+            if success:
+                return
 
-                _LOGGER.warning(
-                    "Connection failed, retrying in %ss...", self._reconnection_timeout
-                )
-                await asyncio.sleep(self._reconnection_timeout)
-
-            return self.connected
+            self._assert_not_stopped()
+            _LOGGER.warning(
+                "Connection failed, retrying in %ss...", self._reconnection_timeout
+            )
+            await asyncio.sleep(self._reconnection_timeout)
 
     async def _close_locked(self) -> None:
         """Close the connection while the connection lock is already held."""
@@ -160,26 +162,44 @@ class SatelConnection:
         _LOGGER.debug("Closing connection...")
         await self._transport.close()
         self._stopped = True
-        self._reconnected_event.set()
+        self._stopped_event.set()
         _LOGGER.info("Connection closed cleanly.")
+
+    async def wait_stopped(self) -> None:
+        """Wait until the connection enters its terminal stopped state."""
+        if self.stopped:
+            return
+
+        await self._stopped_event.wait()
 
     async def close(self) -> None:
         """Close the connection gracefully and clean up."""
         async with self._connection_lock:
             await self._close_locked()
 
-    async def wait_reconnected(self) -> bool:
+    async def wait_reconnected(self) -> None:
         """Wait for connection to be re-established after being lost.
 
         Blocks indefinitely until a reconnection occurs.
-        Returns False if the connection is stopped.
+        Raises if the connection is terminally stopped.
         """
-        if self.stopped:
-            return False
+        self._assert_not_stopped()
 
         self._reconnected_event.clear()
-        await self._reconnected_event.wait()
-        return not self.stopped
+        reconnected_waiter = asyncio.create_task(self._reconnected_event.wait())
+        stopped_waiter = asyncio.create_task(self._stopped_event.wait())
+
+        done, pending = await asyncio.wait(
+            {reconnected_waiter, stopped_waiter},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+
+        if stopped_waiter in done:
+            self._assert_not_stopped()
 
     async def _verify_protocol(self) -> bool:
         """Verify that the panel accepts protocol frames on this transport."""

--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -70,8 +70,7 @@ class SatelConnection:
 
         _LOGGER.debug("Connecting to Satel Integra at %s:%s...", self._host, self._port)
 
-        await self._transport.connect()
-        if not await self._transport.wait_connected():
+        if not await self._transport.connect():
             _LOGGER.warning("Unable to establish TCP connection.")
             await self._close_locked()
             return False

--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -34,7 +34,7 @@ class SatelConnection:
             else SatelPlainTransport(host, port)
         )
 
-        self._closed = False
+        self._stopped = False
         self._connection_lock = asyncio.Lock()  # Prevent concurrent connect/close
         self._reconnected_event = (
             asyncio.Event()
@@ -47,13 +47,13 @@ class SatelConnection:
         return self._transport.connected
 
     @property
-    def closed(self) -> bool:
-        """Return True if the connection is closed."""
-        return self._closed
+    def stopped(self) -> bool:
+        """Return True if the connection is stopped."""
+        return self._stopped
 
     async def _connect(self, verify_connection: bool = True) -> bool:
         """Establish TCP connection. Must be called with _connection_lock held."""
-        if self.closed:
+        if self.stopped:
             _LOGGER.debug("Connection is closed, skipping connection")
             return False
 
@@ -66,14 +66,14 @@ class SatelConnection:
         await self._transport.connect()
         if not await self._transport.wait_connected():
             _LOGGER.warning("Unable to establish TCP connection.")
-            await self.close()
+            await self._close_locked()
             return False
 
         if verify_connection:
             _LOGGER.debug("TCP connection established, verifying panel responsiveness")
             if not await self._check_connection():
                 _LOGGER.warning("Panel not responsive or busy.")
-                await self.close()
+                await self._close_locked()
                 return False
 
             _LOGGER.debug("TCP connection established, verifying protocol round-trip")
@@ -83,7 +83,7 @@ class SatelConnection:
                     "Disabling this client instance; this commonly indicates an "
                     "encryption mismatch or invalid integration key."
                 )
-                await self.close()
+                await self._close_locked()
                 return False
 
         else:
@@ -109,7 +109,7 @@ class SatelConnection:
         connection failure should not trigger automatic retries.
         """
         async with self._connection_lock:
-            if self.closed:
+            if self.stopped:
                 return False
             if self.connected:
                 return True
@@ -128,7 +128,7 @@ class SatelConnection:
         if self.connected:
             return True
 
-        if self.closed:
+        if self.stopped:
             return False
 
         async with self._connection_lock:
@@ -136,12 +136,15 @@ class SatelConnection:
             if self.connected:
                 return True
 
-            if self.closed:
+            if self.stopped:
                 return False
 
             _LOGGER.debug("Not connected, attempting reconnection...")
             success = await self._connect()
             if not success:
+                if self.stopped:
+                    return False
+
                 _LOGGER.warning(
                     "Connection failed, retrying in %ss...", self._reconnection_timeout
                 )
@@ -149,29 +152,34 @@ class SatelConnection:
 
             return self.connected
 
+    async def _close_locked(self) -> None:
+        """Close the connection while the connection lock is already held."""
+        if self.stopped:
+            return
+
+        _LOGGER.debug("Closing connection...")
+        await self._transport.close()
+        self._stopped = True
+        self._reconnected_event.set()
+        _LOGGER.info("Connection closed cleanly.")
+
     async def close(self) -> None:
         """Close the connection gracefully and clean up."""
         async with self._connection_lock:
-            if self.closed:
-                return  # already closed, avoid duplicate calls
-
-            _LOGGER.debug("Closing connection...")
-            await self._transport.close()
-            self._closed = True
-            _LOGGER.info("Connection closed cleanly.")
+            await self._close_locked()
 
     async def wait_reconnected(self) -> bool:
         """Wait for connection to be re-established after being lost.
 
         Blocks indefinitely until a reconnection occurs.
-        Returns False if the connection is closed.
+        Returns False if the connection is stopped.
         """
-        if self.closed:
+        if self.stopped:
             return False
 
         self._reconnected_event.clear()
         await self._reconnected_event.wait()
-        return True
+        return not self.stopped
 
     async def _verify_protocol(self) -> bool:
         """Verify that the panel accepts protocol frames on this transport."""

--- a/satel_integra/encryption.py
+++ b/satel_integra/encryption.py
@@ -1,4 +1,5 @@
 import os
+
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 BLOCK_LENGTH = 16

--- a/satel_integra/exceptions.py
+++ b/satel_integra/exceptions.py
@@ -1,0 +1,13 @@
+"""Custom exceptions for the Satel Integra library."""
+
+
+class SatelIntegraError(Exception):
+    """Base exception for all library-specific errors."""
+
+
+class SatelConnectionError(SatelIntegraError):
+    """Raised when transport connection setup fails."""
+
+
+class SatelConnectionStoppedError(SatelConnectionError):
+    """Raised when the connection has been terminally stopped."""

--- a/satel_integra/queue.py
+++ b/satel_integra/queue.py
@@ -43,7 +43,7 @@ class SatelMessageQueue:
 
         self._current_message: QueuedMessage | None = None
         self._process_task: asyncio.Task | None = None
-        self._closed = False
+        self._stopped = False
 
     async def start(self):
         """Start processing the queue."""
@@ -53,7 +53,7 @@ class SatelMessageQueue:
 
     async def stop(self):
         """Stop the queue gracefully."""
-        self._closed = True
+        self._stopped = True
         if self._process_task:
             self._process_task.cancel()
             try:
@@ -67,7 +67,7 @@ class SatelMessageQueue:
         Queue a message. If wait_for_result is True, wait for and return the result.
         Otherwise, just queue the message and return None
         """
-        if self._closed:
+        if self._stopped:
             raise RuntimeError("Queue is stopped")
 
         _LOGGER.debug("Queueing message: %s", msg)
@@ -88,7 +88,7 @@ class SatelMessageQueue:
         """Process queued commands sequentially."""
         _LOGGER.debug("Message queue worker started")
 
-        while not self._closed:
+        while not self._stopped:
             try:
                 self._current_message = await self._get_next_message()
                 if self._current_message is None:

--- a/satel_integra/queue.py
+++ b/satel_integra/queue.py
@@ -1,10 +1,8 @@
 """Queue class for Satel Integra"""
 
 import asyncio
-from collections.abc import Callable
-
 import logging
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 
 from satel_integra.commands import SatelReadCommand
 from satel_integra.const import MESSAGE_RESPONSE_TIMEOUT

--- a/satel_integra/queue.py
+++ b/satel_integra/queue.py
@@ -18,7 +18,7 @@ class QueuedMessage:
         self.message = message
         self.return_result = wait_for_result
 
-        self.processed_future: asyncio.Future[SatelReadMessage] = (
+        self.processed_future: asyncio.Future[SatelReadMessage | None] = (
             asyncio.get_running_loop().create_future()
         )
 
@@ -62,6 +62,8 @@ class SatelMessageQueue:
                 pass
             self._process_task = None
 
+        self._cancel_pending_messages()
+
     async def add_message(self, msg: SatelWriteMessage, wait_for_result: bool = False):
         """
         Queue a message. If wait_for_result is True, wait for and return the result.
@@ -79,10 +81,25 @@ class SatelMessageQueue:
             return
 
         try:
-            return await queued.processed_future
+            return await asyncio.shield(queued.processed_future)
+        except asyncio.CancelledError:
+            if self._stopped or queued.processed_future.cancelled():
+                _LOGGER.debug("Waiting for message result cancelled")
+                return
+            raise
         except Exception as exc:
             _LOGGER.debug("Couldn't wait for message result: %s", exc)
             return
+
+    def _cancel_pending_messages(self) -> None:
+        """Cancel any pending waiters when the queue shuts down."""
+        if self._current_message and not self._current_message.processed_future.done():
+            self._current_message.processed_future.cancel()
+
+        while not self._queue.empty():
+            queued = self._queue.get_nowait()
+            if not queued.processed_future.done():
+                queued.processed_future.cancel()
 
     async def _process_queue(self) -> None:
         """Process queued commands sequentially."""
@@ -133,6 +150,8 @@ class SatelMessageQueue:
             _LOGGER.error(
                 "No response received from panel within %ss", MESSAGE_RESPONSE_TIMEOUT
             )
+            if not queued.processed_future.done():
+                queued.processed_future.cancel()
             return
 
     def on_message_received(self, result: SatelReadMessage):

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -1,13 +1,14 @@
-# """Main module."""
+"""Main module for Satel Integra alarm system client."""
 
 import asyncio
 import logging
-from warnings import deprecated
+from warnings import deprecated, warn
 from enum import Enum, unique
 from collections.abc import Awaitable, Callable
 
 from satel_integra.commands import SatelReadCommand, SatelWriteCommand
 from satel_integra.connection import SatelConnection
+from typing import overload
 from satel_integra.exceptions import SatelConnectionStoppedError
 from satel_integra.messages import SatelReadMessage, SatelWriteMessage
 from satel_integra.utils import encode_bitmask_le
@@ -416,11 +417,26 @@ class AsyncSatel:
         """Return true if connection is stopped."""
         return self._connection.stopped
 
-    async def connect(self, verify_connection: bool = True) -> bool:
-        """Make a TCP connection to the alarm system."""
-        result = await self._connection.connect(verify_connection=verify_connection)
+    @overload
+    @deprecated("Use connect with 'verify_connection' property instead")
+    async def connect(self, *, check_busy: bool = True) -> bool: ...
 
-        return result
+    @overload
+    async def connect(self, verify_connection: bool = True) -> bool: ...
+
+    async def connect(
+        self, verify_connection: bool = True, *, check_busy: bool = True
+    ) -> bool:
+        """Make a TCP connection to the alarm system."""
+        if check_busy is not None:
+            warn(
+                "'check_busy' is deprecated; use 'verify_connection'",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        verify_connection = check_busy
+
+        return await self._connection.connect(verify_connection=verify_connection)
 
     async def close(self):
         """Stop background tasks and close connection."""

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -6,7 +6,7 @@ import sys
 from collections.abc import Awaitable, Callable
 from enum import Enum, unique
 from typing import overload
-from warnings import deprecated, warn
+from warnings import warn
 
 from satel_integra.commands import SatelReadCommand, SatelWriteCommand
 from satel_integra.connection import SatelConnection

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -409,7 +409,7 @@ class AsyncSatel:
     @property
     @deprecated("Use stopped instead")
     def closed(self) -> bool:
-        """Return true if connection is stopped."""
+        """Return true if connection is closed."""
         return self._connection.stopped
 
     @property
@@ -425,7 +425,7 @@ class AsyncSatel:
     async def connect(self, verify_connection: bool = True) -> bool: ...
 
     async def connect(
-        self, verify_connection: bool = True, *, check_busy: bool = True
+        self, verify_connection: bool = True, *, check_busy: bool | None = None
     ) -> bool:
         """Make a TCP connection to the alarm system."""
         if check_busy is not None:
@@ -434,7 +434,7 @@ class AsyncSatel:
                 DeprecationWarning,
                 stacklevel=2,
             )
-        verify_connection = check_busy
+            verify_connection = check_busy
 
         return await self._connection.connect(verify_connection=verify_connection)
 

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from warnings import deprecated
 from enum import Enum, unique
 from collections.abc import Callable
 
@@ -199,7 +200,8 @@ class AsyncSatel:
     # region Core logic
     async def start(self, enable_monitoring=True):
         """Start the client, including queue, reading loop and keepalive."""
-        await self._connection.ensure_connected()
+        if not await self._connection.ensure_connected():
+            return
 
         # Start reading loop first to ensure we don't miss any messages
         if not self._reading_task or self._reading_task.done():
@@ -227,7 +229,7 @@ class AsyncSatel:
         """
         while True:
             await asyncio.sleep(self._keepalive_timeout)
-            if self.closed:
+            if self.stopped:
                 return
             # Command to read status of the alarm
             data = SatelWriteMessage(
@@ -237,7 +239,7 @@ class AsyncSatel:
 
     async def _reading_loop(self):
         try:
-            while not self.closed:
+            while not self.stopped:
                 await self._connection.ensure_connected()
 
                 msg = await self._read_data()
@@ -268,7 +270,7 @@ class AsyncSatel:
         This task is only created when monitoring is enabled, so we can assume
         monitoring should be restarted on reconnection.
         """
-        while not self.closed:
+        while not self.stopped:
             try:
                 # Wait indefinitely for a reconnection event
                 await self._connection.wait_reconnected()
@@ -391,9 +393,15 @@ class AsyncSatel:
         return self._connection.connected
 
     @property
+    @deprecated("Use stopped instead")
     def closed(self) -> bool:
-        """Return true if connection is closed."""
-        return self._connection.closed
+        """Return true if connection is stopped."""
+        return self._connection.stopped
+
+    @property
+    def stopped(self) -> bool:
+        """Return true if connection is stopped."""
+        return self._connection.stopped
 
     async def connect(self, verify_connection: bool = True) -> bool:
         """Make a TCP connection to the alarm system."""

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -8,6 +8,7 @@ from collections.abc import Awaitable, Callable
 
 from satel_integra.commands import SatelReadCommand, SatelWriteCommand
 from satel_integra.connection import SatelConnection
+from satel_integra.exceptions import SatelConnectionStoppedError
 from satel_integra.messages import SatelReadMessage, SatelWriteMessage
 from satel_integra.utils import encode_bitmask_le
 from satel_integra.queue import SatelMessageQueue
@@ -198,9 +199,12 @@ class AsyncSatel:
     # region Core logic
     async def start(self, enable_monitoring=True):
         """Start the client, including queue, reading loop and keepalive."""
-        if not await self._connection.ensure_connected():
+        try:
+            await self._connection.ensure_connected()
+        except SatelConnectionStoppedError:
             return
 
+        self._start_task(self._watch_connection_stopped())
         self._start_task(self._reading_loop())
 
         await self._queue.start()
@@ -234,9 +238,17 @@ class AsyncSatel:
             )
             await self._send_data(data)
 
+    async def _watch_connection_stopped(self):
+        """Stop local background work once the connection becomes terminally stopped."""
+        try:
+            await self._connection.wait_stopped()
+            await self.close()
+        except asyncio.CancelledError:
+            return
+
     async def _reading_loop(self):
         try:
-            while not self.stopped:
+            while True:
                 await self._connection.ensure_connected()
 
                 msg = await self._read_data()
@@ -256,6 +268,8 @@ class AsyncSatel:
                 else:
                     _LOGGER.debug("No handler for command: %s", msg.cmd)
 
+        except SatelConnectionStoppedError:
+            return
         except asyncio.CancelledError:
             _LOGGER.info("_reading_loop loop cancelled.")
         except Exception as ex:
@@ -267,12 +281,14 @@ class AsyncSatel:
         This task is only created when monitoring is enabled, so we can assume
         monitoring should be restarted on reconnection.
         """
-        while not self.stopped:
+        while True:
             try:
                 # Wait indefinitely for a reconnection event
                 await self._connection.wait_reconnected()
                 _LOGGER.info("Connection re-established, reinitializing monitoring...")
                 await self.start_monitoring()
+            except SatelConnectionStoppedError:
+                return
             except asyncio.CancelledError:
                 break
             except Exception as ex:

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -2,17 +2,35 @@
 
 import asyncio
 import logging
-from warnings import deprecated, warn
-from enum import Enum, unique
+import sys
 from collections.abc import Awaitable, Callable
+from enum import Enum, unique
+from typing import overload
+from warnings import deprecated, warn
 
 from satel_integra.commands import SatelReadCommand, SatelWriteCommand
 from satel_integra.connection import SatelConnection
-from typing import overload
 from satel_integra.exceptions import SatelConnectionStoppedError
 from satel_integra.messages import SatelReadMessage, SatelWriteMessage
-from satel_integra.utils import encode_bitmask_le
 from satel_integra.queue import SatelMessageQueue
+from satel_integra.utils import encode_bitmask_le
+
+if sys.version_info >= (3, 13):
+    from warnings import deprecated
+else:
+    from functools import wraps
+
+    def deprecated(message):
+        def decorator(func):
+            @wraps(func)
+            def wrapper(*args, **kwargs):
+                warn(message, DeprecationWarning, stacklevel=2)
+                return func(*args, **kwargs)
+
+            return wrapper
+
+        return decorator
+
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -395,9 +395,9 @@ class AsyncSatel:
         """Return true if connection is closed."""
         return self._connection.closed
 
-    async def connect(self, check_busy: bool = True) -> bool:
+    async def connect(self, verify_connection: bool = True) -> bool:
         """Make a TCP connection to the alarm system."""
-        result = await self._connection.connect(check_busy=check_busy)
+        result = await self._connection.connect(verify_connection=verify_connection)
 
         return result
 

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from warnings import deprecated
 from enum import Enum, unique
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 
 from satel_integra.commands import SatelReadCommand, SatelWriteCommand
 from satel_integra.connection import SatelConnection
@@ -47,9 +47,7 @@ class AsyncSatel:
         """Init the Satel alarm data."""
         self._connection = SatelConnection(host, port, integration_key=integration_key)
         self._queue = SatelMessageQueue(self._send_encoded_frame)
-        self._reading_task: asyncio.Task | None = None
-        self._reconnection_task: asyncio.Task | None = None
-        self._keepalive_task: asyncio.Task | None = None
+        self._running_tasks: set[asyncio.Task[object]] = set()
         self._keepalive_timeout = 20
 
         self._monitored_zones: list[int] = monitored_zones
@@ -203,23 +201,22 @@ class AsyncSatel:
         if not await self._connection.ensure_connected():
             return
 
-        # Start reading loop first to ensure we don't miss any messages
-        if not self._reading_task or self._reading_task.done():
-            self._reading_task = asyncio.create_task(self._reading_loop())
+        self._start_task(self._reading_loop())
 
         await self._queue.start()
 
-        if not self._keepalive_task or self._keepalive_task.done():
-            self._keepalive_task = asyncio.create_task(self._keepalive_loop())
+        self._start_task(self._keepalive_loop())
 
         if enable_monitoring:
-            # Start reconnection monitor only if monitoring is enabled
-            if not self._reconnection_task or self._reconnection_task.done():
-                self._reconnection_task = asyncio.create_task(
-                    self._monitor_reconnection_loop()
-                )
-
+            self._start_task(self._monitor_reconnection_loop())
             await self.start_monitoring()
+
+    def _start_task(self, coro: Awaitable[object]) -> asyncio.Task[object]:
+        """Create and track a background task."""
+        task = asyncio.create_task(coro)
+        self._running_tasks.add(task)
+        task.add_done_callback(self._running_tasks.discard)
+        return task
 
     async def _keepalive_loop(self):
         """A workaround for Satel Integra disconnecting after 25s.
@@ -410,33 +407,26 @@ class AsyncSatel:
         return result
 
     async def close(self):
-        """Stop monitoring and close connection."""
+        """Stop background tasks and close connection."""
+        await self._connection.close()
+
+        await self._cancel_running_tasks()
         await self._queue.stop()
 
-        if self._reading_task:
-            self._reading_task.cancel()
+    async def _cancel_running_tasks(self) -> None:
+        """Cancel all tracked background tasks except the current one."""
+        current_task = asyncio.current_task()
+        tasks = [task for task in self._running_tasks if task is not current_task]
+
+        for task in tasks:
+            task.cancel()
+
+        for task in tasks:
             try:
-                await self._reading_task
+                await task
             except asyncio.CancelledError:
                 pass
-            self._reading_task = None
 
-        if self._reconnection_task:
-            self._reconnection_task.cancel()
-            try:
-                await self._reconnection_task
-            except asyncio.CancelledError:
-                pass
-            self._reconnection_task = None
-
-        if self._keepalive_task:
-            self._keepalive_task.cancel()
-            try:
-                await self._keepalive_task
-            except asyncio.CancelledError:
-                pass
-            self._keepalive_task = None
-
-        await self._connection.close()
+        self._running_tasks.difference_update(tasks)
 
     # endregion

--- a/satel_integra/transport.py
+++ b/satel_integra/transport.py
@@ -18,25 +18,27 @@ class SatelBaseTransport:
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
 
-        self._connection_event = asyncio.Event()
-
     @property
     def connected(self) -> bool:
         """Return True if connected to the panel."""
         return self._reader is not None and self._writer is not None
 
-    async def connect(self) -> None:
+    async def connect(self) -> bool:
         """Establish TCP connection."""
+
         try:
             self._reader, self._writer = await asyncio.open_connection(
                 self._host, self._port
             )
             _LOGGER.debug("TCP connection established to %s:%s", self._host, self._port)
-            self._connection_event.set()
+            return True
 
         except Exception as exc:
-            _LOGGER.debug("TCP connection failed: %s", exc)
+            _LOGGER.debug(
+                "TCP connection to %s:%s failed: %s", self._host, self._port, exc
+            )
             await self.close()
+            return False
 
     async def read_initial_data(self) -> bytes | None:
         """Read raw data available immediately after TCP connect."""
@@ -112,8 +114,6 @@ class SatelBaseTransport:
 
     async def close(self) -> None:
         """Close the connection gracefully and clean up."""
-        self._connection_event.clear()
-
         if self._writer and not self._writer.is_closing():
             try:
                 self._writer.close()
@@ -123,14 +123,6 @@ class SatelBaseTransport:
 
         self._reader = None
         self._writer = None
-
-    async def wait_connected(self, timeout: float | None = None) -> bool:
-        """Wait until connection is established."""
-        try:
-            await asyncio.wait_for(self._connection_event.wait(), timeout=timeout)
-            return self.connected
-        except asyncio.TimeoutError:
-            return False
 
 
 class SatelPlainTransport(SatelBaseTransport):
@@ -150,9 +142,9 @@ class SatelEncryptedTransport(SatelBaseTransport):
         self._encryption_handler: EncryptedCommunicationHandler
         super().__init__(host, port)
 
-    async def connect(self) -> None:
+    async def connect(self) -> bool:
         self._encryption_handler = EncryptedCommunicationHandler(self._integration_key)
-        await super().connect()
+        return await super().connect()
 
     async def _read_from_transport(self) -> bytes | None:
         """Read encrypted frame end decrypt it."""

--- a/satel_integra/transport.py
+++ b/satel_integra/transport.py
@@ -38,33 +38,13 @@ class SatelBaseTransport:
             _LOGGER.debug("TCP connection failed: %s", exc)
             await self.close()
 
-    async def check_connection(self) -> bool:
-        """Check if the connection is valid and the panel is responsive."""
-        if not self._reader or not self._writer:
-            _LOGGER.warning("Cannot check connection, not connected.")
-            return False
+    async def read_initial_data(self) -> bytes | None:
+        """Read raw data available immediately after TCP connect."""
+        if not self._reader:
+            _LOGGER.warning("Cannot read initial data, not connected.")
+            return None
 
-        try:
-            # Try reading to end of file
-            data = await asyncio.wait_for(self._reader.read(-1), timeout=0.1)
-
-            # Satel returns a string starting with "Busy" when another client is connected
-            if b"Busy" in data:
-                _LOGGER.warning("Panel reports busy (another client is connected).")
-                await self.close()
-                return False
-
-            # We assume any other data is fine, but we log it for debugging reasons
-            _LOGGER.debug("Received data after connect: %s", data)
-        except asyncio.TimeoutError:
-            # Timeout is fine, it means we can actually read data
-            pass
-        except Exception as exc:
-            _LOGGER.debug("Connection check failed: %s", exc)
-            await self.close()
-            return False
-
-        return True
+        return await self._reader.read(-1)
 
     async def read_frame(self) -> bytes | None:
         """Template method for reading a frame from the panel."""

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,6 +1,8 @@
 import asyncio
-import pytest
 from unittest.mock import AsyncMock, MagicMock, PropertyMock
+
+import pytest
+
 from satel_integra.connection import SatelConnection
 
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -55,7 +55,7 @@ async def test_connect_config_failure(mock_connection, mock_transport):
 
     result = await mock_connection.connect()
     assert result is False
-    assert mock_connection.stopped is True
+    assert mock_connection.stopped is False
 
     mock_transport.connect.assert_awaited_once()
     mock_transport.read_initial_data.assert_not_awaited()
@@ -70,7 +70,7 @@ async def test_connect_device_busy_failure(mock_connection, mock_transport):
 
     result = await mock_connection.connect()
     assert result is False
-    assert mock_connection.stopped is True
+    assert mock_connection.stopped is False
 
     mock_transport.read_initial_data.assert_awaited_once()
     mock_transport.close.assert_awaited_once()
@@ -97,7 +97,7 @@ async def test_connect_protocol_probe_failure_closes_connection(
     result = await mock_connection.connect()
 
     assert result is False
-    assert mock_connection.stopped is True
+    assert mock_connection.stopped is False
 
     mock_transport.send_frame.assert_awaited_once()
     mock_transport.read_frame.assert_awaited_once()
@@ -113,7 +113,7 @@ async def test_connect_protocol_probe_timeout_closes_connection(
     result = await mock_connection.connect()
 
     assert result is False
-    assert mock_connection.stopped is True
+    assert mock_connection.stopped is False
     mock_transport.close.assert_awaited_once()
 
 
@@ -158,6 +158,33 @@ async def test_ensure_connected_already_connected(mock_connection, mock_transpor
 async def test_ensure_connected_reconnect(mock_connection, mock_transport):
     await mock_connection.ensure_connected()
     assert mock_transport.connect.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_connected_retries_after_transient_connect_failure(
+    mock_connection, mock_transport, monkeypatch
+):
+    attempts = 0
+
+    async def flaky_connect():
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            mock_transport.connected = False
+            return False
+
+        mock_transport.connected = True
+        return True
+
+    mock_transport.connect = AsyncMock(side_effect=flaky_connect)
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr(asyncio, "sleep", sleep_mock)
+
+    await asyncio.wait_for(mock_connection.ensure_connected(), timeout=1.0)
+
+    assert attempts == 2
+    assert mock_connection.stopped is False
+    sleep_mock.assert_awaited_once_with(mock_connection._reconnection_timeout)
 
 
 @pytest.mark.asyncio

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,19 +1,29 @@
 import asyncio
 import pytest
-from unittest.mock import AsyncMock, MagicMock, PropertyMock
+from unittest.mock import AsyncMock, MagicMock
+
 from satel_integra.connection import SatelConnection
+from satel_integra.exceptions import SatelConnectionStoppedError
+from satel_integra.transport import SatelEncryptedTransport
 
 
 @pytest.fixture
 def mock_transport():
     transport = MagicMock()
-    type(transport).closed = PropertyMock(return_value=False)
-    type(transport).connected = PropertyMock(return_value=False)
+    transport.connected = False
 
-    transport.connect = AsyncMock(return_value=None)
+    async def connect():
+        transport.connected = True
+
+    async def close():
+        transport.connected = False
+
+    transport.connect = AsyncMock(side_effect=connect)
     transport.wait_connected = AsyncMock(return_value=True)
-    transport.check_connection = AsyncMock(return_value=True)
-    transport.close = AsyncMock()
+    transport.read_initial_data = AsyncMock(return_value=b"")
+    transport.send_frame = AsyncMock(return_value=True)
+    transport.read_frame = AsyncMock(return_value=b"probe-response")
+    transport.close = AsyncMock(side_effect=close)
 
     return transport
 
@@ -33,7 +43,9 @@ async def test_connect_success(mock_connection, mock_transport):
 
     mock_transport.connect.assert_awaited_once()
     mock_transport.wait_connected.assert_awaited_once()
-    mock_transport.check_connection.assert_awaited_once()
+    mock_transport.read_initial_data.assert_awaited_once()
+    mock_transport.send_frame.assert_awaited_once()
+    mock_transport.read_frame.assert_awaited_once()
     mock_transport.close.assert_not_awaited()
 
 
@@ -43,86 +55,200 @@ async def test_connect_config_failure(mock_connection, mock_transport):
 
     result = await mock_connection.connect()
     assert result is False
+    assert mock_connection.stopped is True
 
     mock_transport.connect.assert_awaited_once()
     mock_transport.wait_connected.assert_awaited_once()
-    mock_transport.check_connection.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_connect_device_busy_failure(mock_connection, mock_transport):
-    mock_transport.check_connection.return_value = False
-
-    result = await mock_connection.connect()
-    assert result is False
-
-    mock_transport.check_connection.assert_awaited_once()
+    mock_transport.read_initial_data.assert_not_awaited()
+    mock_transport.send_frame.assert_not_awaited()
+    mock_transport.read_frame.assert_not_awaited()
     mock_transport.close.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_connect_skips_busy_check_when_disabled(mock_connection, mock_transport):
-    mock_transport.check_connection.return_value = False
+async def test_connect_device_busy_failure(mock_connection, mock_transport):
+    mock_transport.read_initial_data.return_value = b"Busy!\r\n"
 
-    result = await mock_connection.connect(check_busy=False)
+    result = await mock_connection.connect()
+    assert result is False
+    assert mock_connection.stopped is True
+
+    mock_transport.read_initial_data.assert_awaited_once()
+    mock_transport.close.assert_awaited_once()
+    mock_transport.send_frame.assert_not_awaited()
+    mock_transport.read_frame.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_connect_can_skip_startup_verification(mock_connection, mock_transport):
+    result = await mock_connection.connect(verify_connection=False)
+
+    assert result is True
+    mock_transport.read_initial_data.assert_not_awaited()
+    mock_transport.send_frame.assert_not_awaited()
+    mock_transport.read_frame.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_connect_protocol_probe_failure_closes_connection(
+    mock_connection, mock_transport
+):
+    mock_transport.read_frame.return_value = None
+
+    result = await mock_connection.connect()
+
+    assert result is False
+    assert mock_connection.stopped is True
+
+    mock_transport.send_frame.assert_awaited_once()
+    mock_transport.read_frame.assert_awaited_once()
+    mock_transport.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_connect_protocol_probe_timeout_closes_connection(
+    mock_connection, mock_transport
+):
+    mock_transport.read_frame.side_effect = asyncio.TimeoutError
+
+    result = await mock_connection.connect()
+
+    assert result is False
+    assert mock_connection.stopped is True
+    mock_transport.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_connect_skips_startup_validation_when_disabled(
+    mock_connection, mock_transport
+):
+    mock_transport.read_initial_data.return_value = b"Busy!\r\n"
+
+    result = await mock_connection.connect(verify_connection=False)
     assert result is True
 
     mock_transport.connect.assert_awaited_once()
     mock_transport.wait_connected.assert_awaited_once()
-    mock_transport.check_connection.assert_not_awaited()
+    mock_transport.read_initial_data.assert_not_awaited()
+    mock_transport.send_frame.assert_not_awaited()
+    mock_transport.read_frame.assert_not_awaited()
     mock_transport.close.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_connect_skipped_when_closed(mock_connection, mock_transport):
-    mock_connection._closed = True
+async def test_connect_skipped_when_stopped(mock_connection, mock_transport):
+    mock_connection._stopped = True
 
     result = await mock_connection.connect()
     assert result is False
 
     mock_transport.connect.assert_not_awaited()
-    mock_transport.check_connection.assert_not_awaited()
+    mock_transport.read_initial_data.assert_not_awaited()
     mock_transport.close.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_ensure_connected_already_connected(mock_connection, mock_transport):
-    type(mock_transport).connected = PropertyMock(return_value=True)
+    mock_transport.connected = True
 
-    result = await mock_connection.ensure_connected()
-    assert result is True
+    await mock_connection.ensure_connected()
 
     mock_transport.connect.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_ensure_connected_reconnect(mock_connection, mock_transport):
-    # Simulate disconnected state first, then connected after retry
-    type(mock_transport).connected = PropertyMock(
-        side_effect=[False, False, False, True, True]
-    )
+    await mock_connection.ensure_connected()
+    assert mock_transport.connect.await_count == 1
 
-    result = await mock_connection.ensure_connected()
+
+@pytest.mark.asyncio
+async def test_ensure_connected_raises_when_stopped(mock_connection):
+    mock_connection._stopped = True
+
+    with pytest.raises(SatelConnectionStoppedError):
+        await mock_connection.ensure_connected()
+
+
+@pytest.mark.asyncio
+async def test_check_connection_read_exception(mock_connection, mock_transport):
+    mock_transport.connected = True
+    mock_transport.read_initial_data.side_effect = Exception("boom")
+
+    result = await mock_connection._check_connection()
+
+    assert result is False
+    assert mock_connection.stopped is False
+    mock_transport.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_check_connection_returns_false_when_initial_read_unavailable(
+    mock_connection, mock_transport
+):
+    mock_transport.connected = True
+    mock_transport.read_initial_data.return_value = None
+
+    result = await mock_connection._check_connection()
+
+    assert result is False
+    mock_transport.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_encrypted_check_connection_treats_unexpected_data_as_busy(
+    mock_connection, mock_transport
+):
+    mock_transport.read_initial_data.return_value = b"\x93\xaa\x10\x01"
+    mock_connection._transport = SatelEncryptedTransport(
+        "127.0.0.1", 7094, "abcdefghijkl"
+    )
+    mock_connection._transport.read_initial_data = mock_transport.read_initial_data
+    mock_connection._transport.close = mock_transport.close
+    mock_connection._transport._reader = object()
+    mock_connection._transport._writer = object()
+
+    result = await mock_connection._check_connection()
+
+    assert result is False
+    mock_transport.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_encrypted_check_connection_timeout_is_healthy(
+    mock_connection, mock_transport
+):
+    async def long_read():
+        await asyncio.sleep(999)
+        return b""
+
+    mock_connection._transport = SatelEncryptedTransport(
+        "127.0.0.1", 7094, "abcdefghijkl"
+    )
+    mock_connection._transport.read_initial_data = AsyncMock(side_effect=long_read)
+    mock_connection._transport.close = mock_transport.close
+    mock_connection._transport._reader = object()
+    mock_connection._transport._writer = object()
+
+    result = await mock_connection._check_connection()
 
     assert result is True
-    assert mock_transport.connect.await_count >= 1
+    mock_transport.close.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_close_success(mock_connection, mock_transport):
-    type(mock_transport).connected = PropertyMock(return_value=True)
-
-    assert mock_transport.closed is False
-    assert mock_transport.connected is True
+    mock_transport.connected = True
 
     await mock_connection.close()
 
     mock_transport.close.assert_awaited_once()
+    assert mock_connection.stopped is True
 
 
 @pytest.mark.asyncio
-async def test_close_already_closed(mock_connection, mock_transport):
-    mock_connection._closed = True
+async def test_close_already_stopped(mock_connection, mock_transport):
+    mock_connection._stopped = True
 
     await mock_connection.close()  # should not raise or call anything
 
@@ -152,7 +278,7 @@ async def test_reconnection_event_set_on_subsequent_connect(
     mock_connection._reconnected_event.clear()
 
     # Simulate disconnected state at start of second connect
-    type(mock_transport).connected = PropertyMock(return_value=False)
+    mock_transport.connected = False
 
     await mock_connection.connect()
 
@@ -163,9 +289,7 @@ async def test_reconnection_event_set_on_subsequent_connect(
 async def test_wait_reconnected_blocks_and_returns_true(
     mock_connection, mock_transport
 ):
-    """`wait_reconnected()` should block until `_reconnected_event` is set
-    and then return True (when not closed).
-    """
+    """`wait_reconnected()` should block until `_reconnected_event` is set."""
     # Ensure we've had an initial connection so wait_reconnected will wait for
     # a later reconnection.
     await mock_connection.connect()
@@ -178,5 +302,31 @@ async def test_wait_reconnected_blocks_and_returns_true(
     # Now signal reconnection and await the waiter result
     mock_connection._reconnected_event.set()
 
-    result = await asyncio.wait_for(waiter, timeout=1.0)
-    assert result is True
+    await asyncio.wait_for(waiter, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_wait_reconnected_raises_when_connection_closes(
+    mock_connection, mock_transport
+):
+    await mock_connection.connect()
+
+    waiter = asyncio.create_task(mock_connection.wait_reconnected())
+
+    await asyncio.sleep(0)
+    await mock_connection.close()
+
+    with pytest.raises(SatelConnectionStoppedError):
+        await asyncio.wait_for(waiter, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_wait_stopped_blocks_until_connection_closes(
+    mock_connection, mock_transport
+):
+    waiter = asyncio.create_task(mock_connection.wait_stopped())
+
+    await asyncio.sleep(0)
+    await mock_connection.close()
+
+    await asyncio.wait_for(waiter, timeout=1.0)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, PropertyMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,6 +1,7 @@
 import asyncio
-import pytest
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from satel_integra.connection import SatelConnection
 from satel_integra.exceptions import SatelConnectionStoppedError
@@ -14,12 +15,12 @@ def mock_transport():
 
     async def connect():
         transport.connected = True
+        return True
 
     async def close():
         transport.connected = False
 
     transport.connect = AsyncMock(side_effect=connect)
-    transport.wait_connected = AsyncMock(return_value=True)
     transport.read_initial_data = AsyncMock(return_value=b"")
     transport.send_frame = AsyncMock(return_value=True)
     transport.read_frame = AsyncMock(return_value=b"probe-response")
@@ -42,7 +43,6 @@ async def test_connect_success(mock_connection, mock_transport):
     assert result is True
 
     mock_transport.connect.assert_awaited_once()
-    mock_transport.wait_connected.assert_awaited_once()
     mock_transport.read_initial_data.assert_awaited_once()
     mock_transport.send_frame.assert_awaited_once()
     mock_transport.read_frame.assert_awaited_once()
@@ -51,14 +51,13 @@ async def test_connect_success(mock_connection, mock_transport):
 
 @pytest.mark.asyncio
 async def test_connect_config_failure(mock_connection, mock_transport):
-    mock_transport.wait_connected.return_value = False
+    mock_transport.connect.side_effect = [False]
 
     result = await mock_connection.connect()
     assert result is False
     assert mock_connection.stopped is True
 
     mock_transport.connect.assert_awaited_once()
-    mock_transport.wait_connected.assert_awaited_once()
     mock_transport.read_initial_data.assert_not_awaited()
     mock_transport.send_frame.assert_not_awaited()
     mock_transport.read_frame.assert_not_awaited()
@@ -128,7 +127,6 @@ async def test_connect_skips_startup_validation_when_disabled(
     assert result is True
 
     mock_transport.connect.assert_awaited_once()
-    mock_transport.wait_connected.assert_awaited_once()
     mock_transport.read_initial_data.assert_not_awaited()
     mock_transport.send_frame.assert_not_awaited()
     mock_transport.read_frame.assert_not_awaited()

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -2,8 +2,10 @@
 
 """Tests for encryption module."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
+
 from satel_integra.encryption import EncryptedCommunicationHandler, SatelEncryption
 
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -67,9 +67,22 @@ async def test_stop(mock_queue):
 
     await mock_queue.stop()
 
-    assert mock_queue._closed is True
+    assert mock_queue._stopped is True
     assert task.cancelled()
     assert mock_queue._process_task is None
+
+
+@pytest.mark.asyncio
+async def test_stop_unblocks_waiting_message(mock_queue, write_msg):
+    await mock_queue.start()
+
+    waiter = asyncio.create_task(mock_queue.add_message(write_msg, True))
+    await asyncio.sleep(0)
+
+    await mock_queue.stop()
+
+    result = await asyncio.wait_for(waiter, timeout=1.0)
+    assert result is None
 
 
 @pytest.mark.asyncio
@@ -112,7 +125,7 @@ async def test_stop_cancels_task(mock_queue):
     await mock_queue.start()
     await mock_queue.stop()
     assert mock_queue._process_task is None
-    assert mock_queue._closed is True
+    assert mock_queue._stopped is True
 
 
 @pytest.mark.asyncio
@@ -210,7 +223,7 @@ async def test_process_queue(mock_queue, write_msg):
     queued = QueuedMessage(write_msg, True)
 
     def close_queue_and_return():
-        mock_queue._closed = True
+        mock_queue._stopped = True
         return queued
 
     mock_queue._send_and_wait_response = AsyncMock()
@@ -230,7 +243,7 @@ async def test_process_queue_with_exception(mock_queue, write_msg, caplog):
     queued = QueuedMessage(write_msg, True)
 
     def close_queue_and_return(msg):
-        mock_queue._closed = True
+        mock_queue._stopped = True
         raise Exception("Test exception")
 
     mock_queue._send_and_wait_response = AsyncMock(side_effect=close_queue_and_return)
@@ -246,7 +259,7 @@ async def test_process_queue_with_exception(mock_queue, write_msg, caplog):
 @pytest.mark.asyncio
 async def test_process_queue_skips_none(mock_queue):
     def close_queue():
-        mock_queue._closed = True
+        mock_queue._stopped = True
 
     mock_queue._send_and_wait_response = AsyncMock()
     mock_queue._get_next_message = AsyncMock(side_effect=close_queue, return_value=None)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,11 +1,12 @@
 import asyncio
 import logging
 from unittest.mock import AsyncMock, Mock
+
 import pytest
 
-from satel_integra.queue import SatelMessageQueue, QueuedMessage
-from satel_integra.messages import SatelReadMessage, SatelWriteMessage
 from satel_integra.commands import SatelReadCommand, SatelWriteCommand
+from satel_integra.messages import SatelReadMessage, SatelWriteMessage
+from satel_integra.queue import QueuedMessage, SatelMessageQueue
 
 
 @pytest.fixture

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -1,9 +1,10 @@
 import asyncio
 import logging
-from unittest.mock import AsyncMock, MagicMock, PropertyMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from satel_integra.exceptions import SatelConnectionStoppedError
 from satel_integra.satel_integra import AlarmState, AsyncSatel
 
 
@@ -11,7 +12,10 @@ from satel_integra.satel_integra import AlarmState, AsyncSatel
 def mock_connection():
     conn = AsyncMock()
     conn.connected = True
-    conn.closed = False
+    conn.stopped = False
+    conn.ensure_connected = AsyncMock(return_value=True)
+    conn.wait_reconnected = AsyncMock(return_value=True)
+    conn.wait_stopped = AsyncMock(return_value=None)
     return conn
 
 
@@ -145,13 +149,13 @@ async def test_send_methods_call_queue_add(satel, mock_queue, method, args):
 
 @pytest.mark.asyncio
 async def test_close_cancels_tasks(satel):
-    satel._reading_task = asyncio.create_task(asyncio.sleep(999))
-    satel._keepalive_task = asyncio.create_task(asyncio.sleep(999))
+    reading_task = asyncio.create_task(asyncio.sleep(999))
+    keepalive_task = asyncio.create_task(asyncio.sleep(999))
+    satel._running_tasks = {reading_task, keepalive_task}
 
     await satel.close()
 
-    assert satel._reading_task is None
-    assert satel._keepalive_task is None
+    assert not satel._running_tasks
 
 
 @pytest.mark.asyncio
@@ -164,50 +168,56 @@ async def test_read_data_exception_returns_none(satel):
 
 @pytest.mark.asyncio
 async def test_start_starts_background_tasks(satel):
-    satel._reading_task = None
-    satel._keepalive_task = None
-    satel._reconnection_task = None
-
+    satel._watch_connection_stopped = AsyncMock()
     satel._reading_loop = AsyncMock()
     satel._keepalive_loop = AsyncMock()
     satel._monitor_reconnection_loop = AsyncMock()
+    satel._start_task = MagicMock(side_effect=lambda coro: asyncio.create_task(coro))
     satel.start_monitoring = AsyncMock()
 
     await satel.start(enable_monitoring=True)
 
-    # Tasks are created
-    assert satel._reading_task is not None
-    assert satel._keepalive_task is not None
-    assert satel._reconnection_task is not None
-
-    # Monitoring called
+    assert satel._start_task.call_count == 4
+    satel._connection.ensure_connected.assert_awaited_once()
+    satel._queue.start.assert_awaited_once()
     satel.start_monitoring.assert_awaited()
 
 
 @pytest.mark.asyncio
 async def test_start_skips_monitoring(satel):
-    satel._reading_task = None
-    satel._keepalive_task = None
-    satel._reconnection_task = None
-
+    satel._watch_connection_stopped = AsyncMock()
     satel._reading_loop = AsyncMock()
     satel._keepalive_loop = AsyncMock()
+    satel._start_task = MagicMock(side_effect=lambda coro: asyncio.create_task(coro))
     satel.start_monitoring = AsyncMock()
 
     await satel.start(enable_monitoring=False)
 
-    assert satel._reconnection_task is None
-
+    assert satel._start_task.call_count == 3
     satel.start_monitoring.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_keepalive_loop_sends_message(satel):
-    satel._keepalive_timeout = 0.01
-    satel._send_data = AsyncMock()
+async def test_start_returns_early_when_initial_connection_fails(satel, mock_queue):
+    satel._connection.ensure_connected.side_effect = SatelConnectionStoppedError
+    satel._connection.stopped = True
+    satel._start_task = MagicMock()
+    satel.start_monitoring = AsyncMock()
 
-    # Close after 1 call
-    type(satel).closed = PropertyMock(side_effect=[False, True])
+    await satel.start(enable_monitoring=True)
+
+    satel._start_task.assert_not_called()
+    mock_queue.stop.assert_not_awaited()
+    mock_queue.start.assert_not_awaited()
+    satel.start_monitoring.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_keepalive_loop_stops_when_connection_closes(satel, mock_connection):
+    satel._keepalive_timeout = 0.01
+    satel._send_data = AsyncMock(
+        side_effect=lambda *args, **kwargs: setattr(mock_connection, "stopped", True)
+    )
 
     await satel._keepalive_loop()
 
@@ -215,13 +225,14 @@ async def test_keepalive_loop_sends_message(satel):
 
 
 @pytest.mark.asyncio
-async def test_reading_loop_processes_message(satel):
-    type(satel).closed = PropertyMock(side_effect=[False, True])
-
+async def test_reading_loop_processes_message(satel, mock_connection):
     msg = MagicMock()
     msg.cmd = 1
 
-    satel._read_data = AsyncMock(side_effect=[msg, None])  # Return one msg then None
+    satel._connection.ensure_connected = AsyncMock(
+        side_effect=[None, SatelConnectionStoppedError]
+    )
+    satel._read_data = AsyncMock(return_value=msg)
 
     cmd_handler = MagicMock()
 
@@ -233,7 +244,48 @@ async def test_reading_loop_processes_message(satel):
 
 
 @pytest.mark.asyncio
-async def test_connect_passes_check_busy_flag(satel, mock_connection):
-    await satel.connect(check_busy=False)
+async def test_reading_loop_stops_when_reconnect_closes_connection(
+    satel, mock_connection
+):
+    satel._connection.ensure_connected = AsyncMock(
+        side_effect=SatelConnectionStoppedError
+    )
+    satel._read_data = AsyncMock()
 
-    mock_connection.connect.assert_awaited_once_with(check_busy=False)
+    await satel._reading_loop()
+
+    satel._read_data.assert_not_awaited()
+    satel._queue.stop.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_monitor_reconnection_loop_exits_when_connection_closes(satel):
+    satel._connection.wait_reconnected.side_effect = SatelConnectionStoppedError
+    satel._connection.stopped = True
+    satel.start_monitoring = AsyncMock()
+
+    await satel._monitor_reconnection_loop()
+
+    satel._queue.stop.assert_not_awaited()
+    satel.start_monitoring.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_watch_connection_stopped_stops_queue_and_tasks(satel):
+    satel._running_tasks = {
+        asyncio.create_task(asyncio.sleep(999)),
+        asyncio.create_task(asyncio.sleep(999)),
+        asyncio.create_task(asyncio.sleep(999)),
+    }
+
+    await satel._watch_connection_stopped()
+
+    assert not satel._running_tasks
+    satel._queue.stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_connect_passes_verify_connection_flag(satel, mock_connection):
+    await satel.connect(verify_connection=False)
+
+    mock_connection.connect.assert_awaited_once_with(verify_connection=False)

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -72,39 +72,24 @@ async def test_connect_failure(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_check_connection_busy_message(mock_transport, caplog):
-    mock_transport._reader.read.return_value = (
-        b"\x10Busy!\r\n\xd8\xa5\xa5\xa5\xa5\xa5\xa5\xa5"
-    )
+async def test_read_initial_data(mock_transport):
+    mock_transport._reader.read.return_value = b"Busy!\r\n"
+
+    result = await mock_transport.read_initial_data()
+
+    assert result == b"Busy!\r\n"
+    mock_transport._reader.read.assert_awaited_once_with(-1)
+
+
+@pytest.mark.asyncio
+async def test_read_initial_data_not_connected(caplog):
+    transport = SatelBaseTransport("h", 1)
 
     with caplog.at_level(logging.WARNING):
-        assert await mock_transport.check_connection() is False
+        result = await transport.read_initial_data()
 
-    assert "Panel reports busy (another client is connected)." in caplog.text
-    assert not mock_transport.connected
-
-
-@pytest.mark.asyncio
-async def test_check_connection_read_exception(mock_transport, caplog):
-    mock_transport._reader.read = AsyncMock(side_effect=Exception("Test exception"))
-
-    with caplog.at_level(logging.DEBUG):
-        assert await mock_transport.check_connection() is False
-
-    assert "Connection check failed:" in caplog.text
-    assert not mock_transport.connected
-
-
-@pytest.mark.asyncio
-async def test_check_connection_read_timeout(mock_transport, caplog):
-    async def long_read(length):
-        await asyncio.sleep(999)
-        return ""
-
-    mock_transport._reader.read = AsyncMock(side_effect=long_read)
-
-    assert await mock_transport.check_connection() is True
-    assert mock_transport.connected
+    assert result is None
+    assert "Cannot read initial data, not connected." in caplog.text
 
 
 @pytest.mark.asyncio
@@ -190,8 +175,8 @@ async def test_close_success(mock_transport):
 
 
 @pytest.mark.asyncio
-async def test_close_already_closed(mock_transport):
-    mock_transport.closed = True
+async def test_close_already_stopped(mock_transport):
+    mock_transport.stopped = True
     await mock_transport.close()  # should not raise or call anything
 
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,7 +1,9 @@
 import asyncio
 import logging
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
 from satel_integra.const import FRAME_END
 from satel_integra.transport import SatelBaseTransport, SatelEncryptedTransport
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,7 +1,9 @@
 import asyncio
 import logging
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
 from satel_integra.const import FRAME_END
 from satel_integra.transport import SatelBaseTransport, SatelEncryptedTransport
 
@@ -16,7 +18,6 @@ def mock_transport():
 
     transport = SatelBaseTransport("localhost", 1234)
 
-    transport._connection_event.set()
     transport._reader = reader
     transport._writer = writer
 
@@ -57,7 +58,6 @@ async def test_connect_success(monkeypatch):
     transport = SatelBaseTransport("localhost", 1234)
     await transport.connect()
     assert transport.connected
-    assert await transport.wait_connected() is True
 
 
 @pytest.mark.asyncio
@@ -68,7 +68,6 @@ async def test_connect_failure(monkeypatch):
     transport = SatelBaseTransport("localhost", 1234)
     await transport.connect()
     assert not transport.connected
-    assert await transport.wait_connected(timeout=0.01) is False
 
 
 @pytest.mark.asyncio
@@ -164,14 +163,12 @@ async def test_close_success(mock_transport):
 
     # Verify initial state
     assert mock_transport.connected
-    assert mock_transport._connection_event.is_set()
 
     await mock_transport.close()
 
     assert not mock_transport.connected
     assert mock_transport._reader is None
     assert mock_transport._writer is None
-    assert not mock_transport._connection_event.is_set()
 
 
 @pytest.mark.asyncio

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
-from satel_integra.utils import checksum, decode_bitmask_le, encode_bitmask_le
-
 import pytest
+
+from satel_integra.utils import checksum, decode_bitmask_le, encode_bitmask_le
 
 # List values, byte data, length
 test_frames: list[tuple[list[int], bytearray, int]] = [


### PR DESCRIPTION
Adds the ability to verify the communication protocol after a successful connection was done.
Renamed closed to stopped to better reflect the actual state, a stopped connection will NOT by itself restart or retry, it should be disposed and a new connection should be created.

Additionally some stop logic was cleaned up and improved