### PR TITLE
Add typed Satel exceptions

### DIFF
--- a/satel_integra/__init__.py
+++ b/satel_integra/__init__.py
@@ -1,3 +1,42 @@
 """Top-level package for Satel Integra."""
 
-from .satel_integra import AlarmState, AsyncSatel  # noqa: F401
+from .exceptions import (
+    SatelConnectFailedError,
+    SatelConnectionError,
+    SatelConnectionInitializationError,
+    SatelConnectionSetupError,
+    SatelConnectionStoppedError,
+    SatelEncryptionStateError,
+    SatelFrameDecodeError,
+    SatelIntegraError,
+    SatelMonitoringError,
+    SatelMonitoringRejectedError,
+    SatelPanelBusyError,
+    SatelProtocolError,
+    SatelQueueError,
+    SatelQueueStoppedError,
+    SatelResponseTimeoutError,
+    SatelTransportDisconnectedError,
+)
+from .satel_integra import AlarmState, AsyncSatel
+
+__all__ = [
+    "AlarmState",
+    "AsyncSatel",
+    "SatelConnectFailedError",
+    "SatelConnectionError",
+    "SatelConnectionInitializationError",
+    "SatelConnectionSetupError",
+    "SatelConnectionStoppedError",
+    "SatelEncryptionStateError",
+    "SatelFrameDecodeError",
+    "SatelIntegraError",
+    "SatelMonitoringError",
+    "SatelMonitoringRejectedError",
+    "SatelPanelBusyError",
+    "SatelProtocolError",
+    "SatelQueueError",
+    "SatelQueueStoppedError",
+    "SatelResponseTimeoutError",
+    "SatelTransportDisconnectedError",
+]

--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -138,7 +138,7 @@ class SatelConnection:
                 return
             await self._connect(verify_connection=verify_connection)
 
-    async def read_frame(self) -> bytes | None:
+    async def read_frame(self) -> bytes:
         """Read a raw frame from the panel."""
         return await self._transport.read_frame()
 
@@ -238,7 +238,7 @@ class SatelConnection:
             probe = SatelWriteMessage(SatelWriteCommand.RTC_AND_STATUS)
 
             await self._transport.send_frame(probe.encode_frame())
-            raw_response = await asyncio.wait_for(
+            await asyncio.wait_for(
                 self._transport.read_frame(), timeout=MESSAGE_RESPONSE_TIMEOUT
             )
         except asyncio.TimeoutError as exc:
@@ -263,15 +263,6 @@ class SatelConnection:
                 "Panel did not complete startup protocol verification"
             ) from exc
 
-        if not raw_response:
-            _LOGGER.info(
-                "Startup protocol verification failed: no response received from the "
-                "panel."
-            )
-            raise SatelConnectionInitializationError(
-                "Panel did not return a startup protocol response"
-            )
-
     async def _check_connection(self) -> None:
         """Check if the connection is valid and the panel is responsive."""
         if not self._transport.connected:
@@ -294,12 +285,6 @@ class SatelConnection:
             raise SatelConnectionInitializationError(
                 "Panel failed connection readiness checks"
             ) from exc
-
-        if data is None:
-            _LOGGER.info("Connection check failed: no initial data could be read.")
-            raise SatelConnectionInitializationError(
-                "Panel did not provide startup data during connection check"
-            )
 
         # Satel returns a string starting with "Busy" when another client is connected
         if b"Busy" in data:

--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -5,7 +5,10 @@ import logging
 
 from satel_integra.commands import SatelWriteCommand
 from satel_integra.const import MESSAGE_RESPONSE_TIMEOUT
-from satel_integra.exceptions import SatelConnectionStoppedError
+from satel_integra.exceptions import (
+    SatelConnectFailedError,
+    SatelConnectionStoppedError,
+)
 from satel_integra.messages import SatelWriteMessage
 from satel_integra.transport import (
     SatelBaseTransport,
@@ -70,7 +73,9 @@ class SatelConnection:
 
         _LOGGER.debug("Connecting to Satel Integra at %s:%s...", self._host, self._port)
 
-        if not await self._transport.connect():
+        try:
+            await self._transport.connect()
+        except SatelConnectFailedError:
             _LOGGER.warning("Unable to establish TCP connection.")
             await self._close_locked(stop=False)
             return False

--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -142,7 +142,7 @@ class SatelConnection:
         """Read a raw frame from the panel."""
         return await self._transport.read_frame()
 
-    async def send_frame(self, frame: bytes) -> bool:
+    async def send_frame(self, frame: bytes) -> None:
         """Send a raw frame to the panel."""
         return await self._transport.send_frame(frame)
 

--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -63,15 +63,15 @@ class SatelConnection:
         if self.stopped:
             raise SatelConnectionStoppedError("Connection is stopped")
 
-    async def _connect(self, verify_connection: bool = True) -> bool:
+    async def _connect(self, verify_connection: bool = True) -> None:
         """Establish TCP connection. Must be called with _connection_lock held."""
         if self.stopped:
             _LOGGER.debug("Connection is closed, skipping connection")
-            return False
+            raise SatelConnectionStoppedError("Connection is stopped")
 
         if self.connected:
             _LOGGER.debug("Already connected, skipping connection")
-            return True
+            return
 
         _LOGGER.debug("Connecting to Satel Integra at %s:%s...", self._host, self._port)
 
@@ -80,7 +80,7 @@ class SatelConnection:
         except SatelConnectFailedError:
             _LOGGER.warning("Unable to establish TCP connection.")
             await self._close_locked(stop=False)
-            return False
+            raise
 
         if verify_connection:
             try:
@@ -100,7 +100,7 @@ class SatelConnection:
                     "still be busy."
                 )
                 await self._close_locked(stop=False)
-                return False
+                raise
             except SatelConnectionInitializationError:
                 _LOGGER.warning(
                     "Connected to the panel, but startup validation failed. "
@@ -108,7 +108,7 @@ class SatelConnection:
                     "the panel configuration."
                 )
                 await self._close_locked(stop=False)
-                return False
+                raise
 
         else:
             _LOGGER.debug(
@@ -124,9 +124,8 @@ class SatelConnection:
             self._reconnected_event.set()
 
         self._had_connection = True
-        return True
 
-    async def connect(self, verify_connection: bool = True) -> bool:
+    async def connect(self, verify_connection: bool = True) -> None:
         """Establish TCP connection with a single attempt (no retries).
 
         Acquires lock internally. Suitable for setup validation where a single
@@ -134,10 +133,10 @@ class SatelConnection:
         """
         async with self._connection_lock:
             if self.stopped:
-                return False
+                raise SatelConnectionStoppedError("Connection is stopped")
             if self.connected:
-                return True
-            return await self._connect(verify_connection=verify_connection)
+                return
+            await self._connect(verify_connection=verify_connection)
 
     async def read_frame(self) -> bytes | None:
         """Read a raw frame from the panel."""
@@ -160,10 +159,15 @@ class SatelConnection:
                 self._assert_not_stopped()
 
                 _LOGGER.debug("Not connected, attempting reconnection...")
-                success = await self._connect()
-
-            if success:
-                return
+                try:
+                    await self._connect()
+                    return
+                except (
+                    SatelConnectFailedError,
+                    SatelPanelBusyError,
+                    SatelConnectionInitializationError,
+                ):
+                    self._assert_not_stopped()
 
             self._assert_not_stopped()
             _LOGGER.warning(

--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -7,7 +7,9 @@ from satel_integra.commands import SatelWriteCommand
 from satel_integra.const import MESSAGE_RESPONSE_TIMEOUT
 from satel_integra.exceptions import (
     SatelConnectFailedError,
+    SatelConnectionInitializationError,
     SatelConnectionStoppedError,
+    SatelPanelBusyError,
 )
 from satel_integra.messages import SatelWriteMessage
 from satel_integra.transport import (
@@ -81,8 +83,17 @@ class SatelConnection:
             return False
 
         if verify_connection:
-            _LOGGER.debug("TCP connection established, verifying panel responsiveness")
-            if not await self._check_connection():
+            try:
+                _LOGGER.debug(
+                    "TCP connection established, verifying panel responsiveness"
+                )
+                await self._check_connection()
+
+                _LOGGER.debug(
+                    "TCP connection established, verifying protocol round-trip"
+                )
+                await self._verify_protocol()
+            except SatelPanelBusyError:
                 _LOGGER.warning(
                     "Connected to the panel, but it is not ready for use. "
                     "Another client may already be connected, or the panel may "
@@ -90,9 +101,7 @@ class SatelConnection:
                 )
                 await self._close_locked(stop=False)
                 return False
-
-            _LOGGER.debug("TCP connection established, verifying protocol round-trip")
-            if not await self._verify_protocol():
+            except SatelConnectionInitializationError:
                 _LOGGER.warning(
                     "Connected to the panel, but startup validation failed. "
                     "Check that the integration key and encryption settings match "
@@ -211,13 +220,15 @@ class SatelConnection:
         if stopped_waiter in done:
             self._assert_not_stopped()
 
-    async def _verify_protocol(self) -> bool:
+    async def _verify_protocol(self) -> None:
         """Verify that the panel accepts protocol frames on this transport."""
         if not self._transport.connected:
             _LOGGER.info(
                 "Skipping protocol verification because the transport is not connected."
             )
-            return False
+            raise SatelConnectionInitializationError(
+                "Cannot verify protocol without an active transport connection"
+            )
 
         try:
             probe = SatelWriteMessage(SatelWriteCommand.RTC_AND_STATUS)
@@ -226,6 +237,17 @@ class SatelConnection:
             raw_response = await asyncio.wait_for(
                 self._transport.read_frame(), timeout=MESSAGE_RESPONSE_TIMEOUT
             )
+        except asyncio.TimeoutError as exc:
+            _LOGGER.info(
+                "Startup protocol verification timed out after %ss while waiting "
+                "for the probe response. This can happen when the connection "
+                "settings do not match the panel, for example when encrypted "
+                "frames are sent to an unencrypted panel.",
+                MESSAGE_RESPONSE_TIMEOUT,
+            )
+            raise SatelConnectionInitializationError(
+                "Panel did not respond to the startup protocol probe before timeout"
+            ) from exc
         except Exception as exc:
             _LOGGER.info(
                 "Startup protocol verification failed while sending or reading "
@@ -233,62 +255,69 @@ class SatelConnection:
                 exc,
                 exc_info=True,
             )
-            return False
+            raise SatelConnectionInitializationError(
+                "Panel did not complete startup protocol verification"
+            ) from exc
 
         if not raw_response:
             _LOGGER.info(
                 "Startup protocol verification failed: no response received from the "
                 "panel."
             )
-            return False
+            raise SatelConnectionInitializationError(
+                "Panel did not return a startup protocol response"
+            )
 
-        return True
-
-    async def _check_connection(self) -> bool:
+    async def _check_connection(self) -> None:
         """Check if the connection is valid and the panel is responsive."""
         if not self._transport.connected:
             _LOGGER.info(
                 "Skipping connection check because the transport is not connected."
             )
-            return False
+            raise SatelConnectionInitializationError(
+                "Cannot validate the panel without an active transport connection"
+            )
 
         try:
             data = await asyncio.wait_for(
                 self._transport.read_initial_data(), timeout=0.1
             )
-
-            if data is None:
-                _LOGGER.info("Connection check failed: no initial data could be read.")
-                return False
-
-            # Satel returns a string starting with "Busy" when another client is connected
-            if b"Busy" in data:
-                _LOGGER.info(
-                    "Connection check failed: panel reports busy because another "
-                    "client is connected."
-                )
-                return False
-
-            # Log any other data to debug other potential blocking situation
-            _LOGGER.debug(
-                "Connection check received initial data after connect: %s", data
-            )
-
-            # Encrypted panels appear to return opaque bytes immediately when the
-            # session is already occupied. A healthy encrypted connection times out
-            # here instead.
-            if isinstance(self._transport, SatelEncryptedTransport) and data:
-                _LOGGER.info(
-                    "Connection check failed: encrypted panel returned unexpected "
-                    "initial data, so the session is treated as busy or unavailable."
-                )
-                return False
-
         except asyncio.TimeoutError:
             # Timeout is fine, it means we can actually read data
-            pass
+            return
         except Exception as exc:
             _LOGGER.debug("Connection check failed: %s", exc, exc_info=True)
-            return False
+            raise SatelConnectionInitializationError(
+                "Panel failed connection readiness checks"
+            ) from exc
 
-        return True
+        if data is None:
+            _LOGGER.info("Connection check failed: no initial data could be read.")
+            raise SatelConnectionInitializationError(
+                "Panel did not provide startup data during connection check"
+            )
+
+        # Satel returns a string starting with "Busy" when another client is connected
+        if b"Busy" in data:
+            _LOGGER.info(
+                "Connection check failed: panel reports busy because another "
+                "client is connected."
+            )
+            raise SatelPanelBusyError(
+                "Panel reports busy because another client is connected"
+            )
+
+        # Log any other data to debug other potential blocking situation
+        _LOGGER.debug("Connection check received initial data after connect: %s", data)
+
+        # Encrypted panels appear to return opaque bytes immediately when the
+        # session is already occupied. A healthy encrypted connection times out
+        # here instead.
+        if isinstance(self._transport, SatelEncryptedTransport) and data:
+            _LOGGER.info(
+                "Connection check failed: encrypted panel returned unexpected "
+                "initial data, so the session is treated as busy or unavailable."
+            )
+            raise SatelPanelBusyError(
+                "Encrypted panel returned startup data indicating the session is busy"
+            )

--- a/satel_integra/encryption.py
+++ b/satel_integra/encryption.py
@@ -2,6 +2,8 @@ import os
 
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
+from satel_integra.exceptions import SatelEncryptionStateError
+
 BLOCK_LENGTH = 16
 
 
@@ -146,7 +148,7 @@ class EncryptedCommunicationHandler:
         data = decrypted_pdu[6:]
         self._id_r = header[4]
         if (self._id_s & 0xFF) != decrypted_pdu[5]:
-            raise RuntimeError(
+            raise SatelEncryptionStateError(
                 f"Incorrect value of ID_S, received \\x{decrypted_pdu[5]:x} but expected \\x{self._id_s:x}\n"
                 "Decrypted data: %s" % "".join(f"\\x{x:02x}" for x in decrypted_pdu)
             )

--- a/satel_integra/exceptions.py
+++ b/satel_integra/exceptions.py
@@ -33,6 +33,14 @@ class SatelConnectionStoppedError(SatelConnectionError):
     """Raised when the connection has been terminally stopped."""
 
 
+class SatelMonitoringError(SatelIntegraError):
+    """Raised when monitoring setup does not complete successfully."""
+
+
+class SatelMonitoringRejectedError(SatelMonitoringError):
+    """Raised when the panel rejects a monitoring setup request."""
+
+
 class SatelProtocolError(SatelIntegraError):
     """Base exception for malformed or incompatible protocol data."""
 

--- a/satel_integra/exceptions.py
+++ b/satel_integra/exceptions.py
@@ -31,3 +31,15 @@ class SatelConnectionInitializationError(SatelConnectionSetupError):
 
 class SatelConnectionStoppedError(SatelConnectionError):
     """Raised when the connection has been terminally stopped."""
+
+
+class SatelQueueError(SatelIntegraError):
+    """Base exception for queue-related failures."""
+
+
+class SatelQueueStoppedError(SatelQueueError):
+    """Raised when a message is queued after the queue has stopped."""
+
+
+class SatelResponseTimeoutError(SatelQueueError):
+    """Raised when the panel does not return a response before the timeout."""

--- a/satel_integra/exceptions.py
+++ b/satel_integra/exceptions.py
@@ -9,5 +9,9 @@ class SatelConnectionError(SatelIntegraError):
     """Raised when transport connection setup fails."""
 
 
+class SatelConnectFailedError(SatelConnectionError):
+    """Raised when the TCP connection to the panel cannot be established."""
+
+
 class SatelConnectionStoppedError(SatelConnectionError):
     """Raised when the connection has been terminally stopped."""

--- a/satel_integra/exceptions.py
+++ b/satel_integra/exceptions.py
@@ -13,6 +13,10 @@ class SatelConnectFailedError(SatelConnectionError):
     """Raised when the TCP connection to the panel cannot be established."""
 
 
+class SatelTransportDisconnectedError(SatelConnectionError):
+    """Raised when an established transport connection is lost or unusable."""
+
+
 class SatelConnectionSetupError(SatelConnectionError):
     """Raised when a TCP connection cannot be prepared for use."""
 

--- a/satel_integra/exceptions.py
+++ b/satel_integra/exceptions.py
@@ -33,6 +33,18 @@ class SatelConnectionStoppedError(SatelConnectionError):
     """Raised when the connection has been terminally stopped."""
 
 
+class SatelProtocolError(SatelIntegraError):
+    """Base exception for malformed or incompatible protocol data."""
+
+
+class SatelFrameDecodeError(SatelProtocolError):
+    """Raised when a received frame cannot be decoded successfully."""
+
+
+class SatelEncryptionStateError(SatelProtocolError):
+    """Raised when encrypted session state is invalid or inconsistent."""
+
+
 class SatelQueueError(SatelIntegraError):
     """Base exception for queue-related failures."""
 

--- a/satel_integra/exceptions.py
+++ b/satel_integra/exceptions.py
@@ -13,5 +13,17 @@ class SatelConnectFailedError(SatelConnectionError):
     """Raised when the TCP connection to the panel cannot be established."""
 
 
+class SatelConnectionSetupError(SatelConnectionError):
+    """Raised when a TCP connection cannot be prepared for use."""
+
+
+class SatelPanelBusyError(SatelConnectionSetupError):
+    """Raised when the panel session is occupied by another client."""
+
+
+class SatelConnectionInitializationError(SatelConnectionSetupError):
+    """Raised when the panel does not complete connection setup successfully."""
+
+
 class SatelConnectionStoppedError(SatelConnectionError):
     """Raised when the connection has been terminally stopped."""

--- a/satel_integra/messages.py
+++ b/satel_integra/messages.py
@@ -10,6 +10,7 @@ from satel_integra.const import (
     FRAME_SPECIAL_BYTES_REPLACEMENT,
     FRAME_START,
 )
+from satel_integra.exceptions import SatelFrameDecodeError
 from satel_integra.utils import checksum, decode_bitmask_le, encode_bitmask_le
 
 _LOGGER = logging.getLogger(__name__)
@@ -75,10 +76,10 @@ class SatelReadMessage(SatelBaseMessage[SatelReadCommand]):
         """Verify checksum and strip header/footer of received frame."""
         if data[0:2] != FRAME_START:
             _LOGGER.error("Bad header: %s", data.hex())
-            raise ValueError("Invalid frame header")
+            raise SatelFrameDecodeError("Invalid frame header")
         if data[-2:] != FRAME_END:
             _LOGGER.error("Bad footer: %s", data.hex())
-            raise ValueError("Invalid frame footer")
+            raise SatelFrameDecodeError("Invalid frame footer")
 
         output = data[2:-2].replace(
             FRAME_SPECIAL_BYTES_REPLACEMENT, FRAME_SPECIAL_BYTES
@@ -91,7 +92,7 @@ class SatelReadMessage(SatelBaseMessage[SatelReadCommand]):
             _LOGGER.error(
                 "Checksum mismatch: get %s, expected %s", received_sum, calc_sum
             )
-            raise ValueError(msg)
+            raise SatelFrameDecodeError(msg)
 
         cmd_byte, data = output[0], output[1:-2]
         try:
@@ -99,7 +100,7 @@ class SatelReadMessage(SatelBaseMessage[SatelReadCommand]):
             return SatelReadMessage(cmd, bytearray(data))
         except ValueError as ex:
             _LOGGER.error("Unknown command byte: %s", hex(cmd_byte))
-            raise ValueError("Unknown command byte") from ex
+            raise SatelFrameDecodeError("Unknown command byte") from ex
 
     def get_active_bits(self, expected_length: int) -> list[int]:
         """Convenience wrapper around decode_bitmask_le() for this message."""

--- a/satel_integra/queue.py
+++ b/satel_integra/queue.py
@@ -6,6 +6,7 @@ from collections.abc import Awaitable, Callable
 
 from satel_integra.commands import SatelReadCommand
 from satel_integra.const import MESSAGE_RESPONSE_TIMEOUT
+from satel_integra.exceptions import SatelQueueStoppedError, SatelResponseTimeoutError
 from satel_integra.messages import SatelReadMessage, SatelWriteMessage
 
 _LOGGER = logging.getLogger(__name__)
@@ -68,7 +69,7 @@ class SatelMessageQueue:
         Otherwise, just queue the message and return None
         """
         if self._stopped:
-            raise RuntimeError("Queue is stopped")
+            raise SatelQueueStoppedError("Queue is stopped")
 
         _LOGGER.debug("Queueing message: %s", msg)
 
@@ -78,26 +79,39 @@ class SatelMessageQueue:
         if not wait_for_result:
             return
 
-        try:
-            return await asyncio.shield(queued.processed_future)
-        except asyncio.CancelledError:
-            if self._stopped or queued.processed_future.cancelled():
-                _LOGGER.debug("Waiting for message result cancelled")
-                return
-            raise
-        except Exception as exc:
-            _LOGGER.debug("Couldn't wait for message result: %s", exc)
+        return await asyncio.shield(queued.processed_future)
+
+    def _finish_queued_message(
+        self,
+        queued: QueuedMessage,
+        *,
+        result: SatelReadMessage | None = None,
+        exception: Exception | None = None,
+    ) -> None:
+        """Resolve a queued message future without leaking unhandled exceptions."""
+        if queued.processed_future.done():
             return
 
+        if exception is not None and queued.return_result:
+            queued.processed_future.set_exception(exception)
+            return
+
+        queued.processed_future.set_result(result)
+
     def _cancel_pending_messages(self) -> None:
-        """Cancel any pending waiters when the queue shuts down."""
-        if self._current_message and not self._current_message.processed_future.done():
-            self._current_message.processed_future.cancel()
+        """Resolve any pending waiters when the queue shuts down."""
+        if self._current_message:
+            self._finish_queued_message(
+                self._current_message,
+                exception=SatelQueueStoppedError("Queue is stopped"),
+            )
 
         while not self._queue.empty():
             queued = self._queue.get_nowait()
-            if not queued.processed_future.done():
-                queued.processed_future.cancel()
+            self._finish_queued_message(
+                queued,
+                exception=SatelQueueStoppedError("Queue is stopped"),
+            )
 
     async def _process_queue(self) -> None:
         """Process queued commands sequentially."""
@@ -134,22 +148,25 @@ class SatelMessageQueue:
             await self._send_func(queued.message)
         except Exception as exc:
             _LOGGER.debug("Error while sending message: %s", exc)
-            if not queued.processed_future.done():
-                queued.processed_future.set_exception(exc)
-
+            self._finish_queued_message(queued, exception=exc)
             return
 
         # Wait for the RESULT (the future will be completed by on_message_received).
         try:
             await asyncio.wait_for(
-                queued.processed_future, timeout=MESSAGE_RESPONSE_TIMEOUT
+                asyncio.shield(queued.processed_future),
+                timeout=MESSAGE_RESPONSE_TIMEOUT,
             )
         except asyncio.TimeoutError:
             _LOGGER.error(
                 "No response received from panel within %ss", MESSAGE_RESPONSE_TIMEOUT
             )
-            if not queued.processed_future.done():
-                queued.processed_future.cancel()
+            self._finish_queued_message(
+                queued,
+                exception=SatelResponseTimeoutError(
+                    f"No response received from panel within {MESSAGE_RESPONSE_TIMEOUT}s"
+                ),
+            )
             return
 
     def on_message_received(self, result: SatelReadMessage):
@@ -173,4 +190,4 @@ class SatelMessageQueue:
             )
             return
 
-        self._current_message.processed_future.set_result(result)
+        self._finish_queued_message(self._current_message, result=result)

--- a/satel_integra/queue.py
+++ b/satel_integra/queue.py
@@ -53,6 +53,12 @@ class SatelMessageQueue:
     async def stop(self):
         """Stop the queue gracefully."""
         self._stopped = True
+        await self.stop_processing()
+
+        self._cancel_pending_messages()
+
+    async def stop_processing(self):
+        """Stop the queue worker without terminally stopping the queue."""
         if self._process_task:
             self._process_task.cancel()
             try:
@@ -61,7 +67,7 @@ class SatelMessageQueue:
                 pass
             self._process_task = None
 
-        self._cancel_pending_messages()
+        self._current_message = None
 
     async def add_message(self, msg: SatelWriteMessage, wait_for_result: bool = False):
         """

--- a/satel_integra/queue.py
+++ b/satel_integra/queue.py
@@ -53,12 +53,18 @@ class SatelMessageQueue:
     async def stop(self):
         """Stop the queue gracefully."""
         self._stopped = True
-        await self.stop_processing()
+        await self.stop_processing(SatelQueueStoppedError("Queue is stopped"))
 
-        self._cancel_pending_messages()
-
-    async def stop_processing(self):
+    async def stop_processing(
+        self,
+        exception: Exception | None = None,
+    ):
         """Stop the queue worker without terminally stopping the queue."""
+        if exception is None:
+            exception = SatelQueueStoppedError("Queue processing stopped")
+
+        queued_messages = self._take_pending_messages()
+
         if self._process_task:
             self._process_task.cancel()
             try:
@@ -68,6 +74,7 @@ class SatelMessageQueue:
             self._process_task = None
 
         self._current_message = None
+        self._resolve_pending_messages(queued_messages, exception)
 
     async def add_message(self, msg: SatelWriteMessage, wait_for_result: bool = False):
         """
@@ -104,20 +111,26 @@ class SatelMessageQueue:
 
         queued.processed_future.set_result(result)
 
-    def _cancel_pending_messages(self) -> None:
-        """Resolve any pending waiters when the queue shuts down."""
-        if self._current_message:
-            self._finish_queued_message(
-                self._current_message,
-                exception=SatelQueueStoppedError("Queue is stopped"),
-            )
+    def _take_pending_messages(self) -> list[QueuedMessage]:
+        """Remove and return the current and queued messages."""
+        queued_messages: list[QueuedMessage] = []
+
+        if self._current_message is not None:
+            queued_messages.append(self._current_message)
 
         while not self._queue.empty():
-            queued = self._queue.get_nowait()
-            self._finish_queued_message(
-                queued,
-                exception=SatelQueueStoppedError("Queue is stopped"),
-            )
+            queued_messages.append(self._queue.get_nowait())
+
+        return queued_messages
+
+    def _resolve_pending_messages(
+        self,
+        queued_messages: list[QueuedMessage],
+        exception: Exception,
+    ) -> None:
+        """Resolve queued message futures during queue shutdown or restart."""
+        for queued in queued_messages:
+            self._finish_queued_message(queued, exception=exception)
 
     async def _process_queue(self) -> None:
         """Process queued commands sequentially."""

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -11,7 +11,10 @@ from warnings import warn
 from satel_integra.commands import SatelReadCommand, SatelWriteCommand
 from satel_integra.connection import SatelConnection
 from satel_integra.exceptions import (
+    SatelConnectFailedError,
+    SatelConnectionInitializationError,
     SatelConnectionStoppedError,
+    SatelPanelBusyError,
     SatelProtocolError,
     SatelResponseTimeoutError,
     SatelTransportDisconnectedError,
@@ -125,6 +128,32 @@ class AsyncSatel:
             ),
             SatelReadCommand.RESULT: self._command_result,
         }
+
+    def _should_raise_exceptions(
+        self,
+        method_name: str,
+        raise_exceptions: bool | None,
+    ) -> bool:
+        """Resolve compatibility behavior for public exception handling."""
+        if raise_exceptions is None:
+            warn(
+                f"Calling '{method_name}' without 'raise_exceptions' is deprecated; "
+                "pass raise_exceptions=True to opt in to future behavior.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            return False
+
+        if raise_exceptions is False:
+            warn(
+                f"Calling '{method_name}' with raise_exceptions=False is deprecated "
+                "and will change in a future release.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            return False
+
+        return True
 
     async def start_monitoring(self):
         """Start monitoring for interesting events."""
@@ -444,13 +473,27 @@ class AsyncSatel:
 
     @overload
     @deprecated("Use connect with 'verify_connection' property instead")
-    async def connect(self, *, check_busy: bool = True) -> bool: ...
+    async def connect(
+        self,
+        *,
+        check_busy: bool = True,
+        raise_exceptions: bool | None = None,
+    ) -> bool: ...
 
     @overload
-    async def connect(self, verify_connection: bool = True) -> bool: ...
+    async def connect(
+        self,
+        verify_connection: bool = True,
+        *,
+        raise_exceptions: bool | None = None,
+    ) -> bool: ...
 
     async def connect(
-        self, verify_connection: bool = True, *, check_busy: bool | None = None
+        self,
+        verify_connection: bool = True,
+        *,
+        check_busy: bool | None = None,
+        raise_exceptions: bool | None = None,
     ) -> bool:
         """Make a TCP connection to the alarm system."""
         if check_busy is not None:
@@ -461,7 +504,20 @@ class AsyncSatel:
             )
             verify_connection = check_busy
 
-        return await self._connection.connect(verify_connection=verify_connection)
+        should_raise = self._should_raise_exceptions("connect", raise_exceptions)
+        try:
+            await self._connection.connect(verify_connection=verify_connection)
+        except (
+            SatelConnectFailedError,
+            SatelConnectionInitializationError,
+            SatelPanelBusyError,
+            SatelConnectionStoppedError,
+        ):
+            if should_raise:
+                raise
+            return False
+
+        return True
 
     async def close(self):
         """Stop background tasks and close connection."""

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -14,7 +14,7 @@ from satel_integra.exceptions import (
     SatelConnectFailedError,
     SatelConnectionInitializationError,
     SatelConnectionStoppedError,
-    SatelMonitoringError,
+    SatelIntegraError,
     SatelMonitoringRejectedError,
     SatelPanelBusyError,
     SatelProtocolError,
@@ -271,18 +271,15 @@ class AsyncSatel:
         if enable_monitoring:
             try:
                 await self._start_monitoring()
-            except SatelResponseTimeoutError:
+            except SatelIntegraError as ex:
                 if should_raise:
                     await self._cancel_running_tasks()
                     await self._queue.stop_processing()
                     raise
-                _LOGGER.warning("Start monitoring - no data!")
-            except SatelMonitoringError as ex:
-                if should_raise:
-                    await self._cancel_running_tasks()
-                    await self._queue.stop_processing()
-                    raise
-                _LOGGER.warning("%s", ex)
+                if isinstance(ex, SatelResponseTimeoutError):
+                    _LOGGER.warning("Start monitoring - no data!")
+                else:
+                    _LOGGER.warning("%s", ex)
 
         self._start_task(self._keepalive_loop())
 

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -14,6 +14,8 @@ from satel_integra.exceptions import (
     SatelConnectFailedError,
     SatelConnectionInitializationError,
     SatelConnectionStoppedError,
+    SatelEncryptionStateError,
+    SatelFrameDecodeError,
     SatelIntegraError,
     SatelMonitoringRejectedError,
     SatelPanelBusyError,
@@ -327,6 +329,11 @@ class AsyncSatel:
                 except SatelTransportDisconnectedError:
                     _LOGGER.info("Connection lost while reading data, reconnecting.")
                     continue
+                except SatelFrameDecodeError as ex:
+                    _LOGGER.warning(
+                        "Ignoring unreadable frame in _reading_loop: %s", ex
+                    )
+                    continue
 
                 # Only notify queue of command responses
                 if msg.cmd == SatelReadCommand.RESULT or getattr(
@@ -342,6 +349,9 @@ class AsyncSatel:
 
         except SatelConnectionStoppedError:
             return
+        except SatelEncryptionStateError as ex:
+            _LOGGER.exception("Fatal encryption state error in _reading_loop, %s", ex)
+            await self.close()
         except SatelProtocolError as ex:
             _LOGGER.exception("Fatal protocol error in _reading_loop, %s", ex)
             await self.close()

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -12,7 +12,9 @@ from satel_integra.commands import SatelReadCommand, SatelWriteCommand
 from satel_integra.connection import SatelConnection
 from satel_integra.exceptions import (
     SatelConnectionStoppedError,
+    SatelProtocolError,
     SatelResponseTimeoutError,
+    SatelTransportDisconnectedError,
 )
 from satel_integra.messages import SatelReadMessage, SatelWriteMessage
 from satel_integra.queue import SatelMessageQueue
@@ -277,7 +279,11 @@ class AsyncSatel:
             while True:
                 await self._connection.ensure_connected()
 
-                msg = await self._read_data()
+                try:
+                    msg = await self._read_data()
+                except SatelTransportDisconnectedError:
+                    _LOGGER.info("Connection lost while reading data, reconnecting.")
+                    continue
 
                 if not msg:
                     continue
@@ -296,10 +302,14 @@ class AsyncSatel:
 
         except SatelConnectionStoppedError:
             return
+        except SatelProtocolError as ex:
+            _LOGGER.exception("Fatal protocol error in _reading_loop, %s", ex)
+            await self.close()
         except asyncio.CancelledError:
             _LOGGER.info("_reading_loop loop cancelled.")
         except Exception as ex:
             _LOGGER.exception("Error in _reading_loop loop, %s", ex)
+            await self.close()
 
     async def _monitor_reconnection_loop(self):
         """Monitor for reconnection events and reinitialize monitoring.
@@ -404,24 +414,14 @@ class AsyncSatel:
 
     async def _read_data(self) -> SatelReadMessage | None:
         """Read data from the alarm."""
+        data = await self._connection.read_frame()
 
-        try:
-            data = await self._connection.read_frame()
-
-            if not data:
-                return None
-
-            msg = SatelReadMessage.decode_frame(data)
-            _LOGGER.debug("Received command: %s", msg)
-            return msg
-
-        except Exception as e:
-            _LOGGER.exception("Error reading data: %s", e)
+        if not data:
             return None
 
-        finally:
-            if self._alarm_status_callback:
-                self._alarm_status_callback()
+        msg = SatelReadMessage.decode_frame(data)
+        _LOGGER.debug("Received command: %s", msg)
+        return msg
 
     # endregion
 

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -186,9 +186,6 @@ class AsyncSatel:
 
         monitoring_result = await self._send_data_and_wait(msg)
 
-        if monitoring_result is None:
-            raise SatelMonitoringError("Start monitoring - no data!")
-
         if monitoring_result.msg_data != b"\xff":
             raise SatelMonitoringRejectedError("Monitoring not accepted.")
 
@@ -328,9 +325,6 @@ class AsyncSatel:
                     _LOGGER.info("Connection lost while reading data, reconnecting.")
                     continue
 
-                if not msg:
-                    continue
-
                 # Only notify queue of command responses
                 if msg.cmd == SatelReadCommand.RESULT or getattr(
                     msg.cmd, "expects_same_cmd_response", False
@@ -445,7 +439,7 @@ class AsyncSatel:
         """Add message to the queue."""
         await self._queue.add_message(msg, False)
 
-    async def _send_data_and_wait(self, msg: SatelWriteMessage):
+    async def _send_data_and_wait(self, msg: SatelWriteMessage) -> SatelReadMessage:
         """Add message to the queue and wait for the result."""
         return await self._queue.add_message(msg, True)
 
@@ -455,12 +449,9 @@ class AsyncSatel:
 
         await self._connection.send_frame(data)
 
-    async def _read_data(self) -> SatelReadMessage | None:
+    async def _read_data(self) -> SatelReadMessage:
         """Read data from the alarm."""
         data = await self._connection.read_frame()
-
-        if not data:
-            return None
 
         msg = SatelReadMessage.decode_frame(data)
         _LOGGER.debug("Received command: %s", msg)

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -14,6 +14,8 @@ from satel_integra.exceptions import (
     SatelConnectFailedError,
     SatelConnectionInitializationError,
     SatelConnectionStoppedError,
+    SatelMonitoringError,
+    SatelMonitoringRejectedError,
     SatelPanelBusyError,
     SatelProtocolError,
     SatelResponseTimeoutError,
@@ -155,7 +157,7 @@ class AsyncSatel:
 
         return True
 
-    async def start_monitoring(self):
+    async def _start_monitoring(self) -> None:
         """Start monitoring for interesting events."""
 
         monitored_commands = [
@@ -182,19 +184,13 @@ class AsyncSatel:
             raw_data=bytearray(monitored_commands_bitmask),
         )
 
-        try:
-            monitoring_result = await self._send_data_and_wait(msg)
-        except SatelResponseTimeoutError:
-            _LOGGER.warning("Start monitoring - no data!")
-            return
+        monitoring_result = await self._send_data_and_wait(msg)
 
         if monitoring_result is None:
-            _LOGGER.warning("Start monitoring - no data!")
-            return
+            raise SatelMonitoringError("Start monitoring - no data!")
 
         if monitoring_result.msg_data != b"\xff":
-            _LOGGER.warning("Monitoring not accepted.")
-            return
+            raise SatelMonitoringRejectedError("Monitoring not accepted.")
 
         _LOGGER.debug("Monitoring started")
 
@@ -254,11 +250,20 @@ class AsyncSatel:
             self._alarm_status_callback()
 
     # region Core logic
-    async def start(self, enable_monitoring=True):
+    async def start(
+        self,
+        enable_monitoring: bool = True,
+        *,
+        raise_exceptions: bool | None = None,
+    ):
         """Start the client, including queue, reading loop and keepalive."""
+        should_raise = self._should_raise_exceptions("start", raise_exceptions)
+
         try:
             await self._connection.ensure_connected()
         except SatelConnectionStoppedError:
+            if should_raise:
+                raise
             return
 
         self._start_task(self._watch_connection_stopped())
@@ -270,7 +275,16 @@ class AsyncSatel:
 
         if enable_monitoring:
             self._start_task(self._monitor_reconnection_loop())
-            await self.start_monitoring()
+            try:
+                await self._start_monitoring()
+            except SatelResponseTimeoutError:
+                if should_raise:
+                    raise
+                _LOGGER.warning("Start monitoring - no data!")
+            except SatelMonitoringError as ex:
+                if should_raise:
+                    raise
+                _LOGGER.warning("%s", ex)
 
     def _start_task(self, coro: Awaitable[object]) -> asyncio.Task[object]:
         """Create and track a background task."""
@@ -351,7 +365,7 @@ class AsyncSatel:
                 # Wait indefinitely for a reconnection event
                 await self._connection.wait_reconnected()
                 _LOGGER.info("Connection re-established, reinitializing monitoring...")
-                await self.start_monitoring()
+                await self._start_monitoring()
             except SatelConnectionStoppedError:
                 return
             except asyncio.CancelledError:

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -268,20 +268,26 @@ class AsyncSatel:
 
         await self._queue.start()
 
-        self._start_task(self._keepalive_loop())
-
         if enable_monitoring:
-            self._start_task(self._monitor_reconnection_loop())
             try:
                 await self._start_monitoring()
             except SatelResponseTimeoutError:
                 if should_raise:
+                    await self._cancel_running_tasks()
+                    await self._queue.stop_processing()
                     raise
                 _LOGGER.warning("Start monitoring - no data!")
             except SatelMonitoringError as ex:
                 if should_raise:
+                    await self._cancel_running_tasks()
+                    await self._queue.stop_processing()
                     raise
                 _LOGGER.warning("%s", ex)
+
+        self._start_task(self._keepalive_loop())
+
+        if enable_monitoring:
+            self._start_task(self._monitor_reconnection_loop())
 
     def _start_task(self, coro: Awaitable[object]) -> asyncio.Task[object]:
         """Create and track a background task."""

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -10,7 +10,10 @@ from warnings import warn
 
 from satel_integra.commands import SatelReadCommand, SatelWriteCommand
 from satel_integra.connection import SatelConnection
-from satel_integra.exceptions import SatelConnectionStoppedError
+from satel_integra.exceptions import (
+    SatelConnectionStoppedError,
+    SatelResponseTimeoutError,
+)
 from satel_integra.messages import SatelReadMessage, SatelWriteMessage
 from satel_integra.queue import SatelMessageQueue
 from satel_integra.utils import encode_bitmask_le
@@ -148,7 +151,11 @@ class AsyncSatel:
             raw_data=bytearray(monitored_commands_bitmask),
         )
 
-        monitoring_result = await self._send_data_and_wait(msg)
+        try:
+            monitoring_result = await self._send_data_and_wait(msg)
+        except SatelResponseTimeoutError:
+            _LOGGER.warning("Start monitoring - no data!")
+            return
 
         if monitoring_result is None:
             _LOGGER.warning("Start monitoring - no data!")

--- a/satel_integra/transport.py
+++ b/satel_integra/transport.py
@@ -28,14 +28,13 @@ class SatelBaseTransport:
         """Return True if connected to the panel."""
         return self._reader is not None and self._writer is not None
 
-    async def connect(self) -> bool:
+    async def connect(self) -> None:
         """Establish TCP connection."""
         try:
             self._reader, self._writer = await asyncio.open_connection(
                 self._host, self._port
             )
             _LOGGER.debug("TCP connection established to %s:%s", self._host, self._port)
-            return True
 
         except Exception as exc:
             _LOGGER.debug(
@@ -110,7 +109,7 @@ class SatelBaseTransport:
         """Process the frame (e.g., decrypt). Override in subclass if needed."""
         return raw_data
 
-    async def send_frame(self, frame: bytes) -> bool:
+    async def send_frame(self, frame: bytes) -> None:
         """Template method for writing a frame to the panel."""
         if not self._writer:
             _LOGGER.warning("Cannot write, not connected.")
@@ -127,7 +126,6 @@ class SatelBaseTransport:
             await self._writer.drain()
 
             _LOGGER.debug("Sent raw fame: %s", data.hex())
-            return True
 
         except Exception as exc:
             _LOGGER.debug("Write failed: %s", exc)
@@ -170,9 +168,9 @@ class SatelEncryptedTransport(SatelBaseTransport):
         self._encryption_handler: EncryptedCommunicationHandler
         super().__init__(host, port)
 
-    async def connect(self) -> bool:
+    async def connect(self) -> None:
         self._encryption_handler = EncryptedCommunicationHandler(self._integration_key)
-        return await super().connect()
+        await super().connect()
 
     async def _read_from_transport(self) -> bytes | None:
         """Read encrypted frame end decrypt it."""

--- a/satel_integra/transport.py
+++ b/satel_integra/transport.py
@@ -5,7 +5,10 @@ import logging
 
 from satel_integra.const import FRAME_END
 from satel_integra.encryption import EncryptedCommunicationHandler
-from satel_integra.exceptions import SatelConnectFailedError
+from satel_integra.exceptions import (
+    SatelConnectFailedError,
+    SatelTransportDisconnectedError,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,36 +49,55 @@ class SatelBaseTransport:
         """Read raw data available immediately after TCP connect."""
         if not self._reader:
             _LOGGER.warning("Cannot read initial data, not connected.")
-            return None
+            raise SatelTransportDisconnectedError(
+                "Cannot read initial data because the transport is not connected"
+            )
 
-        return await self._reader.read(-1)
+        try:
+            return await self._reader.read(-1)
+        except Exception as exc:
+            _LOGGER.warning("Initial data read failed: %s", exc)
+            await self.close()
+            raise SatelTransportDisconnectedError(
+                "Transport connection was lost while reading initial data"
+            ) from exc
 
     async def read_frame(self) -> bytes | None:
         """Template method for reading a frame from the panel."""
         if not self._reader:
             _LOGGER.warning("Cannot read, not connected.")
-            return None
+            raise SatelTransportDisconnectedError(
+                "Cannot read a frame because the transport is not connected"
+            )
 
         try:
             raw_data = await self._read_from_transport()
+        except SatelTransportDisconnectedError:
+            raise
+        except asyncio.IncompleteReadError as exc:
+            _LOGGER.warning("Read failed: connection closed while reading a frame.")
+            await self.close()
+            raise SatelTransportDisconnectedError(
+                "Transport connection was lost while reading a frame"
+            ) from exc
+        except Exception as exc:
+            _LOGGER.warning("Read failed: %s", exc)
+            await self.close()
+            raise SatelTransportDisconnectedError(
+                "Transport connection was lost while reading a frame"
+            ) from exc
 
-            if raw_data is None:
-                return None
+        if raw_data is None:
+            return None
 
-            frame = self._process_frame(raw_data)
+        frame = self._process_frame(raw_data)
 
-            if frame and FRAME_END in frame:
-                frame = frame.split(FRAME_END)[0] + FRAME_END
-                _LOGGER.debug("Received raw frame: %s", frame.hex())
-                return frame
-            else:
-                _LOGGER.warning("Read failed, no frame end marker found.")
-        except asyncio.IncompleteReadError:
-            # Incomplete read due to connection closing
-            pass
-        except Exception as e:
-            _LOGGER.warning("Read failed: %s", e)
+        if frame and FRAME_END in frame:
+            frame = frame.split(FRAME_END)[0] + FRAME_END
+            _LOGGER.debug("Received raw frame: %s", frame.hex())
+            return frame
 
+        _LOGGER.warning("Read failed, no frame end marker found.")
         await self.close()
         return None
 
@@ -91,24 +113,27 @@ class SatelBaseTransport:
         """Template method for writing a frame to the panel."""
         if not self._writer:
             _LOGGER.warning("Cannot write, not connected.")
-            return False
+            raise SatelTransportDisconnectedError(
+                "Cannot write a frame because the transport is not connected"
+            )
+
+        data = self._prepare_frame(frame)
+        if not data:
+            raise ValueError("Frame preparation failed or returned empty data")
 
         try:
-            data = self._prepare_frame(frame)
-            if not data:
-                raise ValueError("Frame preparation failed or returned empty data")
-
             self._writer.write(data)
             await self._writer.drain()
 
             _LOGGER.debug("Sent raw fame: %s", data.hex())
             return True
 
-        except Exception as e:
-            _LOGGER.debug("Write failed: %s", e)
+        except Exception as exc:
+            _LOGGER.debug("Write failed: %s", exc)
             await self.close()
-
-            raise
+            raise SatelTransportDisconnectedError(
+                "Transport connection was lost while writing a frame"
+            ) from exc
 
     def _prepare_frame(self, frame: bytes) -> bytes | None:
         """Prepare frame for writing (e.g., encrypt). Override in subclass if needed."""
@@ -152,19 +177,22 @@ class SatelEncryptedTransport(SatelBaseTransport):
         """Read encrypted frame end decrypt it."""
 
         if not self._reader:
-            _LOGGER.warning("Cannot read, not connected.")
-            return None
+            raise SatelTransportDisconnectedError(
+                "Cannot read an encrypted frame because the transport is not connected"
+            )
 
         # first byte tells about data length
         data_len_bytes = await self._reader.read(1)
 
         if not data_len_bytes:
             await self.close()
-            raise ValueError("No data length received, possibly wrong integration key")
+            raise SatelTransportDisconnectedError(
+                "Transport connection was lost while reading encrypted frame length"
+            )
 
         data_len = data_len_bytes[0]
 
-        return await self._reader.read(data_len)
+        return await self._reader.readexactly(data_len)
 
     def _process_frame(self, raw_data: bytes) -> bytes | None:
         _LOGGER.debug("Encrypted frame: %s", raw_data.hex())

--- a/satel_integra/transport.py
+++ b/satel_integra/transport.py
@@ -7,6 +7,7 @@ from satel_integra.const import FRAME_END
 from satel_integra.encryption import EncryptedCommunicationHandler
 from satel_integra.exceptions import (
     SatelConnectFailedError,
+    SatelFrameDecodeError,
     SatelTransportDisconnectedError,
 )
 
@@ -99,7 +100,7 @@ class SatelBaseTransport:
 
         _LOGGER.warning("Read failed, no frame end marker found.")
         await self.close()
-        return None
+        raise SatelFrameDecodeError("Received frame without end marker")
 
     async def _read_from_transport(self) -> bytes | None:
         """Read raw bytes from the transport. Implement in subclass."""

--- a/satel_integra/transport.py
+++ b/satel_integra/transport.py
@@ -5,6 +5,7 @@ import logging
 
 from satel_integra.const import FRAME_END
 from satel_integra.encryption import EncryptedCommunicationHandler
+from satel_integra.exceptions import SatelConnectFailedError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,7 +26,6 @@ class SatelBaseTransport:
 
     async def connect(self) -> bool:
         """Establish TCP connection."""
-
         try:
             self._reader, self._writer = await asyncio.open_connection(
                 self._host, self._port
@@ -38,7 +38,9 @@ class SatelBaseTransport:
                 "TCP connection to %s:%s failed: %s", self._host, self._port, exc
             )
             await self.close()
-            return False
+            raise SatelConnectFailedError(
+                f"Unable to establish TCP connection to {self._host}:{self._port}"
+            ) from exc
 
     async def read_initial_data(self) -> bytes | None:
         """Read raw data available immediately after TCP connect."""

--- a/satel_integra/transport.py
+++ b/satel_integra/transport.py
@@ -45,7 +45,7 @@ class SatelBaseTransport:
                 f"Unable to establish TCP connection to {self._host}:{self._port}"
             ) from exc
 
-    async def read_initial_data(self) -> bytes | None:
+    async def read_initial_data(self) -> bytes:
         """Read raw data available immediately after TCP connect."""
         if not self._reader:
             _LOGGER.warning("Cannot read initial data, not connected.")
@@ -62,7 +62,7 @@ class SatelBaseTransport:
                 "Transport connection was lost while reading initial data"
             ) from exc
 
-    async def read_frame(self) -> bytes | None:
+    async def read_frame(self) -> bytes:
         """Template method for reading a frame from the panel."""
         if not self._reader:
             _LOGGER.warning("Cannot read, not connected.")
@@ -87,9 +87,6 @@ class SatelBaseTransport:
                 "Transport connection was lost while reading a frame"
             ) from exc
 
-        if raw_data is None:
-            return None
-
         frame = self._process_frame(raw_data)
 
         if frame and FRAME_END in frame:
@@ -101,11 +98,11 @@ class SatelBaseTransport:
         await self.close()
         raise SatelFrameDecodeError("Received frame without end marker")
 
-    async def _read_from_transport(self) -> bytes | None:
+    async def _read_from_transport(self) -> bytes:
         """Read raw bytes from the transport. Implement in subclass."""
         raise NotImplementedError
 
-    def _process_frame(self, raw_data: bytes) -> bytes | None:
+    def _process_frame(self, raw_data: bytes) -> bytes:
         """Process the frame (e.g., decrypt). Override in subclass if needed."""
         return raw_data
 
@@ -134,7 +131,7 @@ class SatelBaseTransport:
                 "Transport connection was lost while writing a frame"
             ) from exc
 
-    def _prepare_frame(self, frame: bytes) -> bytes | None:
+    def _prepare_frame(self, frame: bytes) -> bytes:
         """Prepare frame for writing (e.g., encrypt). Override in subclass if needed."""
         return frame
 
@@ -152,10 +149,12 @@ class SatelBaseTransport:
 
 
 class SatelPlainTransport(SatelBaseTransport):
-    async def _read_from_transport(self) -> bytes | None:
+    async def _read_from_transport(self) -> bytes:
         """Read until frame end marker."""
         if self._reader is None:
-            return None
+            raise SatelTransportDisconnectedError(
+                "Cannot read a frame because the transport is not connected"
+            )
 
         return await self._reader.readuntil(FRAME_END)
 
@@ -172,7 +171,7 @@ class SatelEncryptedTransport(SatelBaseTransport):
         self._encryption_handler = EncryptedCommunicationHandler(self._integration_key)
         await super().connect()
 
-    async def _read_from_transport(self) -> bytes | None:
+    async def _read_from_transport(self) -> bytes:
         """Read encrypted frame end decrypt it."""
 
         if not self._reader:
@@ -193,13 +192,13 @@ class SatelEncryptedTransport(SatelBaseTransport):
 
         return await self._reader.readexactly(data_len)
 
-    def _process_frame(self, raw_data: bytes) -> bytes | None:
+    def _process_frame(self, raw_data: bytes) -> bytes:
         _LOGGER.debug("Encrypted frame: %s", raw_data.hex())
         decrypted_frame = self._encryption_handler.extract_data_from_pdu(raw_data)
         _LOGGER.debug("Decrypted frame: %s", decrypted_frame.hex())
         return decrypted_frame
 
-    def _prepare_frame(self, frame: bytes) -> bytes | None:
+    def _prepare_frame(self, frame: bytes) -> bytes:
         """Send a raw frame to the panel."""
         _LOGGER.debug("Frame before encryption: %s", frame.hex())
         encrypted_frame = self._encryption_handler.prepare_pdu(frame)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -44,8 +44,7 @@ def mock_connection(mock_transport: AsyncMock) -> SatelConnection:
 
 @pytest.mark.asyncio
 async def test_connect_success(mock_connection, mock_transport):
-    result = await mock_connection.connect()
-    assert result is True
+    await mock_connection.connect()
 
     mock_transport.connect.assert_awaited_once()
     mock_transport.read_initial_data.assert_awaited_once()
@@ -58,8 +57,8 @@ async def test_connect_success(mock_connection, mock_transport):
 async def test_connect_config_failure(mock_connection, mock_transport):
     mock_transport.connect.side_effect = SatelConnectFailedError("boom")
 
-    result = await mock_connection.connect()
-    assert result is False
+    with pytest.raises(SatelConnectFailedError, match="boom"):
+        await mock_connection.connect()
     assert mock_connection.stopped is False
 
     mock_transport.connect.assert_awaited_once()
@@ -73,8 +72,11 @@ async def test_connect_config_failure(mock_connection, mock_transport):
 async def test_connect_device_busy_failure(mock_connection, mock_transport):
     mock_transport.read_initial_data.return_value = b"Busy!\r\n"
 
-    result = await mock_connection.connect()
-    assert result is False
+    with pytest.raises(
+        SatelPanelBusyError,
+        match="Panel reports busy because another client is connected",
+    ):
+        await mock_connection.connect()
     assert mock_connection.stopped is False
 
     mock_transport.read_initial_data.assert_awaited_once()
@@ -99,9 +101,8 @@ async def test_check_connection_raises_busy_when_panel_reports_busy(
 
 @pytest.mark.asyncio
 async def test_connect_can_skip_startup_verification(mock_connection, mock_transport):
-    result = await mock_connection.connect(verify_connection=False)
+    await mock_connection.connect(verify_connection=False)
 
-    assert result is True
     mock_transport.read_initial_data.assert_not_awaited()
     mock_transport.send_frame.assert_not_awaited()
     mock_transport.read_frame.assert_not_awaited()
@@ -113,9 +114,12 @@ async def test_connect_protocol_probe_failure_closes_connection(
 ):
     mock_transport.read_frame.return_value = None
 
-    result = await mock_connection.connect()
+    with pytest.raises(
+        SatelConnectionInitializationError,
+        match="Panel did not return a startup protocol response",
+    ):
+        await mock_connection.connect()
 
-    assert result is False
     assert mock_connection.stopped is False
 
     mock_transport.send_frame.assert_awaited_once()
@@ -129,9 +133,12 @@ async def test_connect_protocol_probe_timeout_closes_connection(
 ):
     mock_transport.read_frame.side_effect = asyncio.TimeoutError
 
-    result = await mock_connection.connect()
+    with pytest.raises(
+        SatelConnectionInitializationError,
+        match="Panel did not respond to the startup protocol probe before timeout",
+    ):
+        await mock_connection.connect()
 
-    assert result is False
     assert mock_connection.stopped is False
     mock_transport.close.assert_awaited_once()
 
@@ -142,8 +149,7 @@ async def test_connect_skips_startup_validation_when_disabled(
 ):
     mock_transport.read_initial_data.return_value = b"Busy!\r\n"
 
-    result = await mock_connection.connect(verify_connection=False)
-    assert result is True
+    await mock_connection.connect(verify_connection=False)
 
     mock_transport.connect.assert_awaited_once()
     mock_transport.read_initial_data.assert_not_awaited()
@@ -153,11 +159,38 @@ async def test_connect_skips_startup_validation_when_disabled(
 
 
 @pytest.mark.asyncio
+async def test_connect_raises_when_stopped_and_raise_exceptions_enabled(
+    mock_connection, mock_transport
+):
+    mock_connection._stopped = True
+
+    with pytest.raises(SatelConnectionStoppedError, match="Connection is stopped"):
+        await mock_connection.connect()
+
+    mock_transport.connect.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_connect_raises_startup_failure_when_raise_exceptions_enabled(
+    mock_connection, mock_transport
+):
+    mock_transport.read_frame.return_value = None
+
+    with pytest.raises(
+        SatelConnectionInitializationError,
+        match="Panel did not return a startup protocol response",
+    ):
+        await mock_connection.connect()
+
+    mock_transport.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_connect_skipped_when_stopped(mock_connection, mock_transport):
     mock_connection._stopped = True
 
-    result = await mock_connection.connect()
-    assert result is False
+    with pytest.raises(SatelConnectionStoppedError, match="Connection is stopped"):
+        await mock_connection.connect()
 
     mock_transport.connect.assert_not_awaited()
     mock_transport.read_initial_data.assert_not_awaited()
@@ -190,7 +223,7 @@ async def test_ensure_connected_retries_after_transient_connect_failure(
         attempts += 1
         if attempts == 1:
             mock_transport.connected = False
-            return False
+            raise SatelConnectFailedError("boom")
 
         mock_transport.connected = True
         return True
@@ -344,8 +377,7 @@ async def test_reconnection_event_set_on_subsequent_connect(
     waiters are notified.
     """
     # First connect (initial connection)
-    result = await mock_connection.connect()
-    assert result is True
+    await mock_connection.connect()
 
     # After initial connect, we have had a connection but the reconnection
     # event should not be set.

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -6,7 +6,9 @@ import pytest
 from satel_integra.connection import SatelConnection
 from satel_integra.exceptions import (
     SatelConnectFailedError,
+    SatelConnectionInitializationError,
     SatelConnectionStoppedError,
+    SatelPanelBusyError,
 )
 from satel_integra.transport import SatelEncryptedTransport
 
@@ -79,6 +81,20 @@ async def test_connect_device_busy_failure(mock_connection, mock_transport):
     mock_transport.close.assert_awaited_once()
     mock_transport.send_frame.assert_not_awaited()
     mock_transport.read_frame.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_check_connection_raises_busy_when_panel_reports_busy(
+    mock_connection, mock_transport
+):
+    mock_transport.connected = True
+    mock_transport.read_initial_data.return_value = b"Busy!\r\n"
+
+    with pytest.raises(
+        SatelPanelBusyError,
+        match="Panel reports busy because another client is connected",
+    ):
+        await mock_connection._check_connection()
 
 
 @pytest.mark.asyncio
@@ -203,23 +219,29 @@ async def test_check_connection_read_exception(mock_connection, mock_transport):
     mock_transport.connected = True
     mock_transport.read_initial_data.side_effect = Exception("boom")
 
-    result = await mock_connection._check_connection()
+    with pytest.raises(
+        SatelConnectionInitializationError,
+        match="Panel failed connection readiness checks",
+    ):
+        await mock_connection._check_connection()
 
-    assert result is False
     assert mock_connection.stopped is False
     mock_transport.close.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_check_connection_returns_false_when_initial_read_unavailable(
+async def test_check_connection_raises_when_initial_read_unavailable(
     mock_connection, mock_transport
 ):
     mock_transport.connected = True
     mock_transport.read_initial_data.return_value = None
 
-    result = await mock_connection._check_connection()
+    with pytest.raises(
+        SatelConnectionInitializationError,
+        match="Panel did not provide startup data during connection check",
+    ):
+        await mock_connection._check_connection()
 
-    assert result is False
     mock_transport.close.assert_not_awaited()
 
 
@@ -236,9 +258,12 @@ async def test_encrypted_check_connection_treats_unexpected_data_as_busy(
     mock_connection._transport._reader = object()
     mock_connection._transport._writer = object()
 
-    result = await mock_connection._check_connection()
+    with pytest.raises(
+        SatelPanelBusyError,
+        match="Encrypted panel returned startup data indicating the session is busy",
+    ):
+        await mock_connection._check_connection()
 
-    assert result is False
     mock_transport.close.assert_not_awaited()
 
 
@@ -260,8 +285,34 @@ async def test_encrypted_check_connection_timeout_is_healthy(
 
     result = await mock_connection._check_connection()
 
-    assert result is True
+    assert result is None
     mock_transport.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_verify_protocol_raises_when_panel_returns_no_response(
+    mock_connection, mock_transport
+):
+    mock_transport.connected = True
+    mock_transport.read_frame.return_value = None
+
+    with pytest.raises(
+        SatelConnectionInitializationError,
+        match="Panel did not return a startup protocol response",
+    ):
+        await mock_connection._verify_protocol()
+
+
+@pytest.mark.asyncio
+async def test_verify_protocol_raises_on_read_timeout(mock_connection, mock_transport):
+    mock_transport.connected = True
+    mock_transport.read_frame.side_effect = asyncio.TimeoutError
+
+    with pytest.raises(
+        SatelConnectionInitializationError,
+        match="Panel did not respond to the startup protocol probe before timeout",
+    ):
+        await mock_connection._verify_protocol()
 
 
 @pytest.mark.asyncio

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4,7 +4,10 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from satel_integra.connection import SatelConnection
-from satel_integra.exceptions import SatelConnectionStoppedError
+from satel_integra.exceptions import (
+    SatelConnectFailedError,
+    SatelConnectionStoppedError,
+)
 from satel_integra.transport import SatelEncryptedTransport
 
 
@@ -51,7 +54,7 @@ async def test_connect_success(mock_connection, mock_transport):
 
 @pytest.mark.asyncio
 async def test_connect_config_failure(mock_connection, mock_transport):
-    mock_transport.connect.side_effect = [False]
+    mock_transport.connect.side_effect = SatelConnectFailedError("boom")
 
     result = await mock_connection.connect()
     assert result is False

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -9,6 +9,7 @@ from satel_integra.exceptions import (
     SatelConnectionInitializationError,
     SatelConnectionStoppedError,
     SatelPanelBusyError,
+    SatelTransportDisconnectedError,
 )
 from satel_integra.transport import SatelEncryptedTransport
 
@@ -112,11 +113,10 @@ async def test_connect_can_skip_startup_verification(mock_connection, mock_trans
 async def test_connect_protocol_probe_failure_closes_connection(
     mock_connection, mock_transport
 ):
-    mock_transport.read_frame.return_value = None
-
+    mock_transport.read_frame.side_effect = SatelTransportDisconnectedError("boom")
     with pytest.raises(
         SatelConnectionInitializationError,
-        match="Panel did not return a startup protocol response",
+        match="Panel did not complete startup protocol verification",
     ):
         await mock_connection.connect()
 
@@ -174,11 +174,10 @@ async def test_connect_raises_when_stopped_and_raise_exceptions_enabled(
 async def test_connect_raises_startup_failure_when_raise_exceptions_enabled(
     mock_connection, mock_transport
 ):
-    mock_transport.read_frame.return_value = None
-
+    mock_transport.read_frame.side_effect = SatelTransportDisconnectedError("boom")
     with pytest.raises(
         SatelConnectionInitializationError,
-        match="Panel did not return a startup protocol response",
+        match="Panel did not complete startup protocol verification",
     ):
         await mock_connection.connect()
 
@@ -263,22 +262,6 @@ async def test_check_connection_read_exception(mock_connection, mock_transport):
 
 
 @pytest.mark.asyncio
-async def test_check_connection_raises_when_initial_read_unavailable(
-    mock_connection, mock_transport
-):
-    mock_transport.connected = True
-    mock_transport.read_initial_data.return_value = None
-
-    with pytest.raises(
-        SatelConnectionInitializationError,
-        match="Panel did not provide startup data during connection check",
-    ):
-        await mock_connection._check_connection()
-
-    mock_transport.close.assert_not_awaited()
-
-
-@pytest.mark.asyncio
 async def test_encrypted_check_connection_treats_unexpected_data_as_busy(
     mock_connection, mock_transport
 ):
@@ -323,15 +306,14 @@ async def test_encrypted_check_connection_timeout_is_healthy(
 
 
 @pytest.mark.asyncio
-async def test_verify_protocol_raises_when_panel_returns_no_response(
+async def test_verify_protocol_raises_when_probe_read_fails(
     mock_connection, mock_transport
 ):
     mock_transport.connected = True
-    mock_transport.read_frame.return_value = None
-
+    mock_transport.read_frame.side_effect = SatelTransportDisconnectedError("boom")
     with pytest.raises(
         SatelConnectionInitializationError,
-        match="Panel did not return a startup protocol response",
+        match="Panel did not complete startup protocol verification",
     ):
         await mock_connection._verify_protocol()
 

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from satel_integra.encryption import EncryptedCommunicationHandler, SatelEncryption
+from satel_integra.exceptions import SatelEncryptionStateError
 
 
 class TestProtocol:
@@ -72,7 +73,7 @@ class TestProtocol:
                 communication_handler.extract_data_from_pdu(
                     b"12345%bsome_message" % current_id_s.to_bytes(1, "big")
                 )
-                with pytest.raises(RuntimeError):
+                with pytest.raises(SatelEncryptionStateError):
                     communication_handler.extract_data_from_pdu(
                         b"12345%bsome_message" % (current_id_s + 1).to_bytes(1, "big")
                     )

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -78,6 +78,22 @@ async def test_stop(mock_queue):
 
 
 @pytest.mark.asyncio
+async def test_stop_processing_cancels_worker_without_stopping_queue(mock_queue):
+    async def dummy_coro():
+        await asyncio.sleep(999)
+
+    task = asyncio.create_task(dummy_coro())
+
+    mock_queue._process_task = task
+
+    await mock_queue.stop_processing()
+
+    assert mock_queue._stopped is False
+    assert task.cancelled()
+    assert mock_queue._process_task is None
+
+
+@pytest.mark.asyncio
 async def test_stop_unblocks_waiting_message(mock_queue, write_msg):
     await mock_queue.start()
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -107,6 +107,21 @@ async def test_stop_unblocks_waiting_message(mock_queue, write_msg):
 
 
 @pytest.mark.asyncio
+async def test_stop_processing_unblocks_in_flight_waiting_message(
+    mock_queue, write_msg
+):
+    await mock_queue.start()
+
+    waiter = asyncio.create_task(mock_queue.add_message(write_msg, True))
+    await asyncio.sleep(0.05)
+
+    await mock_queue.stop_processing()
+
+    with pytest.raises(SatelQueueStoppedError, match="Queue processing stopped"):
+        await asyncio.wait_for(waiter, timeout=1.0)
+
+
+@pytest.mark.asyncio
 async def test_queued_message_init(write_msg):
     message = QueuedMessage(write_msg, False)
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -5,6 +5,10 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 
 from satel_integra.commands import SatelReadCommand, SatelWriteCommand
+from satel_integra.exceptions import (
+    SatelQueueStoppedError,
+    SatelResponseTimeoutError,
+)
 from satel_integra.messages import SatelReadMessage, SatelWriteMessage
 from satel_integra.queue import QueuedMessage, SatelMessageQueue
 
@@ -82,8 +86,8 @@ async def test_stop_unblocks_waiting_message(mock_queue, write_msg):
 
     await mock_queue.stop()
 
-    result = await asyncio.wait_for(waiter, timeout=1.0)
-    assert result is None
+    with pytest.raises(SatelQueueStoppedError, match="Queue is stopped"):
+        await asyncio.wait_for(waiter, timeout=1.0)
 
 
 @pytest.mark.asyncio
@@ -95,7 +99,7 @@ async def test_queued_message_init(write_msg):
 
 
 @pytest.mark.asyncio
-async def test_queued_message_init_same_cmd():
+async def test_queued_message_uses_echo_response_command_when_needed():
     write_msg = SatelWriteMessage(SatelWriteCommand.READ_DEVICE_NAME)
     message = QueuedMessage(write_msg, True)
 
@@ -130,7 +134,9 @@ async def test_stop_cancels_task(mock_queue):
 
 
 @pytest.mark.asyncio
-async def test_add_message_wait_for_result(mock_queue, write_msg, result_msg):
+async def test_add_message_returns_matching_result_for_waiting_caller(
+    mock_queue, write_msg, result_msg
+):
     await mock_queue.start()
 
     async def complete_result():
@@ -147,7 +153,9 @@ async def test_add_message_wait_for_result(mock_queue, write_msg, result_msg):
 
 
 @pytest.mark.asyncio
-async def test_add_message_no_wait(mock_queue, write_msg):
+async def test_add_message_returns_none_for_fire_and_forget_caller(
+    mock_queue, write_msg
+):
     await mock_queue.start()
     result = await mock_queue.add_message(write_msg, False)
     await asyncio.sleep(0.05)
@@ -163,12 +171,14 @@ async def test_add_message_after_stop_raises(mock_queue, write_msg):
     await mock_queue.start()
     await mock_queue.stop()
 
-    with pytest.raises(RuntimeError, match="Queue is stopped"):
+    with pytest.raises(SatelQueueStoppedError, match="Queue is stopped"):
         await mock_queue.add_message(write_msg)
 
 
 @pytest.mark.asyncio
-async def test_on_message_received_correct(mock_queue, write_msg, result_msg):
+async def test_on_message_received_resolves_current_matching_message(
+    mock_queue, write_msg, result_msg
+):
     queued = QueuedMessage(write_msg, True)
     mock_queue._current_message = queued
 
@@ -178,7 +188,9 @@ async def test_on_message_received_correct(mock_queue, write_msg, result_msg):
 
 
 @pytest.mark.asyncio
-async def test_on_message_received_commmand_mismatch(mock_queue, result_msg, caplog):
+async def test_on_message_received_logs_and_ignores_command_mismatch(
+    mock_queue, result_msg, caplog
+):
     caplog.at_level(logging.WARNING)
 
     queued = QueuedMessage(SatelWriteMessage(SatelWriteCommand.READ_DEVICE_NAME), True)
@@ -220,7 +232,7 @@ async def test_on_message_received_future_already_done(
 
 
 @pytest.mark.asyncio
-async def test_process_queue(mock_queue, write_msg):
+async def test_process_queue_processes_one_message_before_stop(mock_queue, write_msg):
     queued = QueuedMessage(write_msg, True)
 
     def close_queue_and_return():
@@ -238,7 +250,9 @@ async def test_process_queue(mock_queue, write_msg):
 
 
 @pytest.mark.asyncio
-async def test_process_queue_with_exception(mock_queue, write_msg, caplog):
+async def test_process_queue_logs_unexpected_worker_exception(
+    mock_queue, write_msg, caplog
+):
     caplog.at_level(logging.WARNING)
 
     queued = QueuedMessage(write_msg, True)
@@ -272,10 +286,10 @@ async def test_process_queue_skips_none(mock_queue):
 
 
 @pytest.mark.asyncio
-async def test_send_and_wait_response_success(mock_queue, write_msg, result_msg):
-    mock_queue._send_func = AsyncMock()
-
-    queued = QueuedMessage(write_msg, False)
+async def test_send_and_wait_response_awaits_precompleted_result(
+    mock_queue, write_msg, result_msg
+):
+    queued = QueuedMessage(write_msg, True)
     queued.processed_future.set_result(result_msg)
 
     await mock_queue._send_and_wait_response(queued)
@@ -286,12 +300,12 @@ async def test_send_and_wait_response_success(mock_queue, write_msg, result_msg)
 
 
 @pytest.mark.asyncio
-async def test_send_and_wait_response_send_func_exception(
+async def test_send_and_wait_response_sets_send_exception_for_waiting_message(
     mock_queue, write_msg, caplog
 ):
     mock_queue._send_func = AsyncMock(side_effect=ConnectionError("Test exception"))
 
-    queued = QueuedMessage(write_msg, False)
+    queued = QueuedMessage(write_msg, True)
 
     with caplog.at_level(logging.DEBUG):
         await mock_queue._send_and_wait_response(queued)
@@ -304,12 +318,10 @@ async def test_send_and_wait_response_send_func_exception(
 
 
 @pytest.mark.asyncio
-async def test_send_and_wait_response_timeout(
+async def test_send_and_wait_response_sets_timeout_exception_for_waiting_message(
     mock_queue, write_msg, caplog, monkeypatch
 ):
-    mock_queue._send_func = AsyncMock()
-
-    queued = QueuedMessage(write_msg, False)
+    queued = QueuedMessage(write_msg, True)
 
     # Use a very short timeout for faster test
     monkeypatch.setattr("satel_integra.queue.MESSAGE_RESPONSE_TIMEOUT", 0.01)
@@ -319,4 +331,20 @@ async def test_send_and_wait_response_timeout(
 
     assert "No response received from panel within" in caplog.text
     assert queued.processed_future.done()
-    assert queued.processed_future.cancelled()
+    exc = queued.processed_future.exception()
+    assert isinstance(exc, SatelResponseTimeoutError)
+    assert str(exc) == "No response received from panel within 0.01s"
+
+
+@pytest.mark.asyncio
+async def test_send_and_wait_response_timeout_completes_fire_and_forget_message(
+    mock_queue, write_msg, monkeypatch
+):
+    queued = QueuedMessage(write_msg, False)
+
+    monkeypatch.setattr("satel_integra.queue.MESSAGE_RESPONSE_TIMEOUT", 0.01)
+
+    await mock_queue._send_and_wait_response(queued)
+
+    assert queued.processed_future.done()
+    assert queued.processed_future.result() is None

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -6,7 +6,9 @@ import pytest
 
 from satel_integra.exceptions import (
     SatelConnectionStoppedError,
+    SatelFrameDecodeError,
     SatelResponseTimeoutError,
+    SatelTransportDisconnectedError,
 )
 from satel_integra.satel_integra import AlarmState, AsyncSatel
 
@@ -171,11 +173,11 @@ async def test_close_cancels_tasks(satel):
 
 
 @pytest.mark.asyncio
-async def test_read_data_exception_returns_none(satel):
+async def test_read_data_exception_raises(satel):
     satel._connection.read_frame.side_effect = Exception("boom")
 
-    result = await satel._read_data()
-    assert result is None
+    with pytest.raises(Exception, match="boom"):
+        await satel._read_data()
 
 
 @pytest.mark.asyncio
@@ -253,6 +255,38 @@ async def test_reading_loop_processes_message(satel, mock_connection):
     await satel._reading_loop()
 
     cmd_handler.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_reading_loop_retries_after_temporary_disconnect(satel, mock_connection):
+    msg = MagicMock()
+    msg.cmd = 1
+
+    satel._connection.ensure_connected = AsyncMock(
+        side_effect=[None, None, SatelConnectionStoppedError]
+    )
+    satel._read_data = AsyncMock(
+        side_effect=[SatelTransportDisconnectedError("temporary"), msg]
+    )
+    cmd_handler = MagicMock()
+    satel._message_handlers = {1: cmd_handler}
+
+    await satel._reading_loop()
+
+    assert satel._read_data.await_count == 2
+    cmd_handler.assert_called_once_with(msg)
+    satel._connection.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reading_loop_closes_on_unexpected_receive_error(satel, mock_connection):
+    satel._connection.ensure_connected = AsyncMock(side_effect=[None])
+    satel._read_data = AsyncMock(side_effect=SatelFrameDecodeError("bad frame"))
+
+    await satel._reading_loop()
+
+    satel._connection.close.assert_awaited_once()
+    satel._queue.stop.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from satel_integra.exceptions import (
+    SatelConnectionInitializationError,
     SatelConnectionStoppedError,
     SatelFrameDecodeError,
     SatelResponseTimeoutError,
@@ -189,7 +190,7 @@ async def test_start_starts_background_tasks(satel):
     satel._start_task = MagicMock(side_effect=lambda coro: asyncio.create_task(coro))
     satel.start_monitoring = AsyncMock()
 
-    await satel.start(enable_monitoring=True)
+    await satel.start(enable_monitoring=True, raise_exceptions=False)
 
     assert satel._start_task.call_count == 4
     satel._connection.ensure_connected.assert_awaited_once()
@@ -205,10 +206,29 @@ async def test_start_skips_monitoring(satel):
     satel._start_task = MagicMock(side_effect=lambda coro: asyncio.create_task(coro))
     satel.start_monitoring = AsyncMock()
 
-    await satel.start(enable_monitoring=False)
+    await satel.start(enable_monitoring=False, raise_exceptions=False)
 
     assert satel._start_task.call_count == 3
     satel.start_monitoring.assert_not_awaited()
+
+
+def test_connect_warns_when_raise_exceptions_not_provided(satel, mock_connection):
+    with pytest.deprecated_call(match="Calling 'connect' without 'raise_exceptions'"):
+        asyncio.run(satel.connect())
+
+
+@pytest.mark.asyncio
+async def test_connect_warns_when_raise_exceptions_false(satel):
+    with pytest.deprecated_call(match="Calling 'connect' with raise_exceptions=False"):
+        await satel.connect(raise_exceptions=False)
+
+
+@pytest.mark.asyncio
+async def test_connect_raises_when_enabled(satel, mock_connection):
+    mock_connection.connect.side_effect = SatelConnectionInitializationError("boom")
+
+    with pytest.raises(SatelConnectionInitializationError, match="boom"):
+        await satel.connect(raise_exceptions=True)
 
 
 @pytest.mark.asyncio
@@ -218,7 +238,7 @@ async def test_start_returns_early_when_initial_connection_fails(satel, mock_que
     satel._start_task = MagicMock()
     satel.start_monitoring = AsyncMock()
 
-    await satel.start(enable_monitoring=True)
+    await satel.start(enable_monitoring=True, raise_exceptions=False)
 
     satel._start_task.assert_not_called()
     mock_queue.stop.assert_not_awaited()
@@ -332,6 +352,6 @@ async def test_watch_connection_stopped_stops_queue_and_tasks(satel):
 
 @pytest.mark.asyncio
 async def test_connect_passes_verify_connection_flag(satel, mock_connection):
-    await satel.connect(verify_connection=False)
+    await satel.connect(verify_connection=False, raise_exceptions=False)
 
     mock_connection.connect.assert_awaited_once_with(verify_connection=False)

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -8,7 +8,6 @@ from satel_integra.exceptions import (
     SatelConnectionInitializationError,
     SatelConnectionStoppedError,
     SatelFrameDecodeError,
-    SatelMonitoringError,
     SatelMonitoringRejectedError,
     SatelResponseTimeoutError,
     SatelTransportDisconnectedError,
@@ -72,14 +71,6 @@ async def test_internal_start_monitoring_rejected_raises(satel, mock_queue):
     mock_queue.add_message.return_value = mock_msg
 
     with pytest.raises(SatelMonitoringRejectedError, match="Monitoring not accepted"):
-        await satel._start_monitoring()
-
-
-@pytest.mark.asyncio
-async def test_internal_start_monitoring_no_data_raises(satel, mock_queue):
-    mock_queue.add_message.return_value = None
-
-    with pytest.raises(SatelMonitoringError, match="Start monitoring - no data!"):
         await satel._start_monitoring()
 
 

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -7,6 +7,7 @@ import pytest
 from satel_integra.exceptions import (
     SatelConnectionInitializationError,
     SatelConnectionStoppedError,
+    SatelEncryptionStateError,
     SatelFrameDecodeError,
     SatelMonitoringRejectedError,
     SatelResponseTimeoutError,
@@ -387,9 +388,31 @@ async def test_reading_loop_retries_after_temporary_disconnect(satel, mock_conne
 
 
 @pytest.mark.asyncio
-async def test_reading_loop_closes_on_unexpected_receive_error(satel, mock_connection):
+async def test_reading_loop_ignores_frame_decode_error_and_continues(
+    satel, mock_connection
+):
+    msg = MagicMock()
+    msg.cmd = 1
+
+    satel._connection.ensure_connected = AsyncMock(
+        side_effect=[None, None, SatelConnectionStoppedError]
+    )
+    satel._read_data = AsyncMock(side_effect=[SatelFrameDecodeError("bad frame"), msg])
+
+    cmd_handler = MagicMock()
+    satel._message_handlers = {1: cmd_handler}
+
+    await satel._reading_loop()
+
+    cmd_handler.assert_called_once_with(msg)
+    satel._connection.close.assert_not_awaited()
+    satel._queue.stop.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reading_loop_closes_on_encryption_state_error(satel, mock_connection):
     satel._connection.ensure_connected = AsyncMock(side_effect=[None])
-    satel._read_data = AsyncMock(side_effect=SatelFrameDecodeError("bad frame"))
+    satel._read_data = AsyncMock(side_effect=SatelEncryptionStateError("bad state"))
 
     await satel._reading_loop()
 

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -296,6 +296,16 @@ async def test_start_swallows_monitoring_setup_failure_in_compat_mode(
 
 
 @pytest.mark.asyncio
+async def test_start_swallows_monitoring_transport_failure_in_compat_mode(
+    satel, mock_queue
+):
+    mock_queue.add_message.side_effect = SatelTransportDisconnectedError("temporary")
+
+    with pytest.deprecated_call(match="Calling 'start' with raise_exceptions=False"):
+        await satel.start(enable_monitoring=True, raise_exceptions=False)
+
+
+@pytest.mark.asyncio
 async def test_start_warns_when_raise_exceptions_false(satel):
     with pytest.deprecated_call(match="Calling 'start' with raise_exceptions=False"):
         await satel.start(raise_exceptions=False)

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -4,7 +4,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from satel_integra.exceptions import SatelConnectionStoppedError
+from satel_integra.exceptions import (
+    SatelConnectionStoppedError,
+    SatelResponseTimeoutError,
+)
 from satel_integra.satel_integra import AlarmState, AsyncSatel
 
 
@@ -66,6 +69,15 @@ async def test_start_monitoring_rejected(satel, mock_queue, caplog):
     await satel.start_monitoring()
 
     assert "Monitoring not accepted" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_start_monitoring_timeout_logs_no_data(satel, mock_queue, caplog):
+    mock_queue.add_message.side_effect = SatelResponseTimeoutError("timeout")
+
+    await satel.start_monitoring()
+
+    assert "Start monitoring - no data!" in caplog.text
 
 
 def test_zones_violated_callback(satel):

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -8,6 +8,8 @@ from satel_integra.exceptions import (
     SatelConnectionInitializationError,
     SatelConnectionStoppedError,
     SatelFrameDecodeError,
+    SatelMonitoringError,
+    SatelMonitoringRejectedError,
     SatelResponseTimeoutError,
     SatelTransportDisconnectedError,
 )
@@ -53,34 +55,40 @@ def satel(monkeypatch, mock_connection, mock_queue):
 
 
 @pytest.mark.asyncio
-async def test_start_monitoring_success(satel, mock_queue):
+async def test_internal_start_monitoring_success(satel, mock_queue):
     mock_msg = MagicMock()
     mock_msg.msg_data = b"\xff"
     mock_queue.add_message.return_value = mock_msg
 
-    await satel.start_monitoring()
+    await satel._start_monitoring()
 
     mock_queue.add_message.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_start_monitoring_rejected(satel, mock_queue, caplog):
+async def test_internal_start_monitoring_rejected_raises(satel, mock_queue):
     mock_msg = MagicMock()
     mock_msg.msg_data = b"\x00"
     mock_queue.add_message.return_value = mock_msg
 
-    await satel.start_monitoring()
-
-    assert "Monitoring not accepted" in caplog.text
+    with pytest.raises(SatelMonitoringRejectedError, match="Monitoring not accepted"):
+        await satel._start_monitoring()
 
 
 @pytest.mark.asyncio
-async def test_start_monitoring_timeout_logs_no_data(satel, mock_queue, caplog):
+async def test_internal_start_monitoring_no_data_raises(satel, mock_queue):
+    mock_queue.add_message.return_value = None
+
+    with pytest.raises(SatelMonitoringError, match="Start monitoring - no data!"):
+        await satel._start_monitoring()
+
+
+@pytest.mark.asyncio
+async def test_internal_start_monitoring_timeout_raises(satel, mock_queue):
     mock_queue.add_message.side_effect = SatelResponseTimeoutError("timeout")
 
-    await satel.start_monitoring()
-
-    assert "Start monitoring - no data!" in caplog.text
+    with pytest.raises(SatelResponseTimeoutError, match="timeout"):
+        await satel._start_monitoring()
 
 
 def test_zones_violated_callback(satel):
@@ -188,14 +196,14 @@ async def test_start_starts_background_tasks(satel):
     satel._keepalive_loop = AsyncMock()
     satel._monitor_reconnection_loop = AsyncMock()
     satel._start_task = MagicMock(side_effect=lambda coro: asyncio.create_task(coro))
-    satel.start_monitoring = AsyncMock()
+    satel._start_monitoring = AsyncMock()
 
     await satel.start(enable_monitoring=True, raise_exceptions=False)
 
     assert satel._start_task.call_count == 4
     satel._connection.ensure_connected.assert_awaited_once()
     satel._queue.start.assert_awaited_once()
-    satel.start_monitoring.assert_awaited()
+    satel._start_monitoring.assert_awaited()
 
 
 @pytest.mark.asyncio
@@ -204,12 +212,12 @@ async def test_start_skips_monitoring(satel):
     satel._reading_loop = AsyncMock()
     satel._keepalive_loop = AsyncMock()
     satel._start_task = MagicMock(side_effect=lambda coro: asyncio.create_task(coro))
-    satel.start_monitoring = AsyncMock()
+    satel._start_monitoring = AsyncMock()
 
     await satel.start(enable_monitoring=False, raise_exceptions=False)
 
     assert satel._start_task.call_count == 3
-    satel.start_monitoring.assert_not_awaited()
+    satel._start_monitoring.assert_not_awaited()
 
 
 def test_connect_warns_when_raise_exceptions_not_provided(satel, mock_connection):
@@ -232,18 +240,72 @@ async def test_connect_raises_when_enabled(satel, mock_connection):
 
 
 @pytest.mark.asyncio
+async def test_start_warns_when_raise_exceptions_not_provided(satel):
+    with pytest.deprecated_call(match="Calling 'start' without 'raise_exceptions'"):
+        await satel.start()
+
+
+@pytest.mark.asyncio
+async def test_start_raises_when_enabled_and_monitoring_setup_fails(satel):
+    satel._start_monitoring = AsyncMock(
+        side_effect=SatelResponseTimeoutError("timeout")
+    )
+
+    with pytest.raises(SatelResponseTimeoutError, match="timeout"):
+        await satel.start(enable_monitoring=True, raise_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_start_swallows_monitoring_rejection_in_compat_mode(
+    satel, mock_queue, caplog
+):
+    mock_msg = MagicMock()
+    mock_msg.msg_data = b"\x00"
+    mock_queue.add_message.return_value = mock_msg
+
+    with pytest.deprecated_call(match="Calling 'start' with raise_exceptions=False"):
+        await satel.start(enable_monitoring=True, raise_exceptions=False)
+
+    assert "Monitoring not accepted." in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_start_swallows_monitoring_setup_failure_in_compat_mode(
+    satel, mock_queue
+):
+    mock_queue.add_message.side_effect = SatelResponseTimeoutError("timeout")
+
+    with pytest.deprecated_call(match="Calling 'start' with raise_exceptions=False"):
+        await satel.start(enable_monitoring=True, raise_exceptions=False)
+
+
+@pytest.mark.asyncio
+async def test_start_warns_when_raise_exceptions_false(satel):
+    with pytest.deprecated_call(match="Calling 'start' with raise_exceptions=False"):
+        await satel.start(raise_exceptions=False)
+
+
+@pytest.mark.asyncio
+async def test_start_raises_when_enabled_and_connection_is_stopped(satel):
+    satel._connection.ensure_connected.side_effect = SatelConnectionStoppedError("stop")
+
+    with pytest.raises(SatelConnectionStoppedError, match="stop"):
+        await satel.start(raise_exceptions=True)
+
+
+@pytest.mark.asyncio
 async def test_start_returns_early_when_initial_connection_fails(satel, mock_queue):
     satel._connection.ensure_connected.side_effect = SatelConnectionStoppedError
     satel._connection.stopped = True
     satel._start_task = MagicMock()
-    satel.start_monitoring = AsyncMock()
+    satel._start_monitoring = AsyncMock()
 
     await satel.start(enable_monitoring=True, raise_exceptions=False)
 
     satel._start_task.assert_not_called()
     mock_queue.stop.assert_not_awaited()
     mock_queue.start.assert_not_awaited()
-    satel.start_monitoring.assert_not_awaited()
+    satel._start_monitoring.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -328,12 +390,12 @@ async def test_reading_loop_stops_when_reconnect_closes_connection(
 async def test_monitor_reconnection_loop_exits_when_connection_closes(satel):
     satel._connection.wait_reconnected.side_effect = SatelConnectionStoppedError
     satel._connection.stopped = True
-    satel.start_monitoring = AsyncMock()
+    satel._start_monitoring = AsyncMock()
 
     await satel._monitor_reconnection_loop()
 
     satel._queue.stop.assert_not_awaited()
-    satel.start_monitoring.assert_not_awaited()
+    satel._start_monitoring.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -247,6 +247,31 @@ async def test_start_raises_when_enabled_and_monitoring_setup_fails(satel):
 
 
 @pytest.mark.asyncio
+async def test_start_cleans_up_started_runtime_when_monitoring_setup_fails_in_strict_mode(
+    satel,
+):
+    satel._watch_connection_stopped = AsyncMock()
+    satel._reading_loop = AsyncMock()
+    satel._keepalive_loop = AsyncMock()
+    satel._monitor_reconnection_loop = AsyncMock()
+    satel._start_task = MagicMock(side_effect=lambda coro: asyncio.create_task(coro))
+    satel._cancel_running_tasks = AsyncMock()
+    satel._start_monitoring = AsyncMock(
+        side_effect=SatelResponseTimeoutError("timeout")
+    )
+
+    with pytest.raises(SatelResponseTimeoutError, match="timeout"):
+        await satel.start(enable_monitoring=True, raise_exceptions=True)
+
+    assert satel._start_task.call_count == 2
+    satel._queue.start.assert_awaited_once()
+    satel._queue.stop_processing.assert_awaited_once()
+    satel._cancel_running_tasks.assert_awaited_once()
+    satel._keepalive_loop.assert_not_awaited()
+    satel._monitor_reconnection_loop.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_start_swallows_monitoring_rejection_in_compat_mode(
     satel, mock_queue, caplog
 ):

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -7,6 +7,7 @@ import pytest
 from satel_integra.const import FRAME_END
 from satel_integra.exceptions import (
     SatelConnectFailedError,
+    SatelFrameDecodeError,
     SatelTransportDisconnectedError,
 )
 from satel_integra.transport import SatelBaseTransport, SatelEncryptedTransport
@@ -136,6 +137,19 @@ async def test_read_frame_peer_reset_raises_disconnected(mock_transport):
     with pytest.raises(
         SatelTransportDisconnectedError,
         match="Transport connection was lost while reading a frame",
+    ):
+        await mock_transport.read_frame()
+
+    assert not mock_transport.connected
+
+
+@pytest.mark.asyncio
+async def test_read_frame_without_end_marker_raises_decode_error(mock_transport):
+    mock_transport._read_from_transport = AsyncMock(return_value=b"not-a-frame")
+
+    with pytest.raises(
+        SatelFrameDecodeError,
+        match="Received frame without end marker",
     ):
         await mock_transport.read_frame()
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -176,8 +176,7 @@ async def test_read_frame_incomplete_read_raises_disconnected(mock_transport):
 async def test_send_frame_success(mock_transport):
     frame = b"abc"
 
-    result = await mock_transport.send_frame(frame)
-    assert result
+    await mock_transport.send_frame(frame)
     mock_transport._writer.write.assert_called_once_with(frame)
     mock_transport._writer.drain.assert_awaited_once()
 
@@ -288,8 +287,7 @@ async def test_write_encrypted(encryption_handler, mock_encrypted_transport):
 
     assert mock_encrypted_transport._encryption_handler is not None
 
-    result = await mock_encrypted_transport.send_frame(b"some_plain_data")
-    assert result
+    await mock_encrypted_transport.send_frame(b"some_plain_data")
     encryption_handler_inst.prepare_pdu.assert_called_with(b"some_plain_data")
     mock_encrypted_transport._writer.write.assert_called_once_with(
         bytes([len(encrypted_data)]) + encrypted_data

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -5,7 +5,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from satel_integra.const import FRAME_END
-from satel_integra.exceptions import SatelConnectFailedError
+from satel_integra.exceptions import (
+    SatelConnectFailedError,
+    SatelTransportDisconnectedError,
+)
 from satel_integra.transport import SatelBaseTransport, SatelEncryptedTransport
 
 
@@ -92,9 +95,12 @@ async def test_read_initial_data_not_connected(caplog):
     transport = SatelBaseTransport("h", 1)
 
     with caplog.at_level(logging.WARNING):
-        result = await transport.read_initial_data()
+        with pytest.raises(
+            SatelTransportDisconnectedError,
+            match="Cannot read initial data because the transport is not connected",
+        ):
+            await transport.read_initial_data()
 
-    assert result is None
     assert "Cannot read initial data, not connected." in caplog.text
 
 
@@ -113,27 +119,43 @@ async def test_read_frame_success(mock_transport):
 @pytest.mark.asyncio
 async def test_read_frame_not_connected():
     transport = SatelBaseTransport("h", 1)
-    result = await transport.read_frame()
-    assert result is None
+
+    with pytest.raises(
+        SatelTransportDisconnectedError,
+        match="Cannot read a frame because the transport is not connected",
+    ):
+        await transport.read_frame()
 
 
 @pytest.mark.asyncio
-async def test_read_frame_failure(mock_transport):
-    mock_transport._read_from_transport = AsyncMock(side_effect=Exception("boom"))
+async def test_read_frame_peer_reset_raises_disconnected(mock_transport):
+    mock_transport._read_from_transport = AsyncMock(
+        side_effect=ConnectionResetError("boom")
+    )
 
-    result = await mock_transport.read_frame()
-    assert result is None
+    with pytest.raises(
+        SatelTransportDisconnectedError,
+        match="Transport connection was lost while reading a frame",
+    ):
+        await mock_transport.read_frame()
+
     assert not mock_transport.connected
 
 
 @pytest.mark.asyncio
-async def test_read_frame_timeout(mock_transport):
-    mock_transport._read_from_transport = AsyncMock(side_effect=asyncio.TimeoutError)
+async def test_read_frame_incomplete_read_raises_disconnected(mock_transport):
+    mock_transport._read_from_transport = AsyncMock(
+        side_effect=asyncio.IncompleteReadError(partial=b"", expected=1)
+    )
 
-    result = await mock_transport.read_frame()
-    assert result is None
+    with pytest.raises(
+        SatelTransportDisconnectedError,
+        match="Transport connection was lost while reading a frame",
+    ):
+        await mock_transport.read_frame()
+
     mock_transport._read_from_transport.assert_awaited_once()
-    assert not mock_transport.connected  # Should disconnect on timeout
+    assert not mock_transport.connected
 
 
 @pytest.mark.asyncio
@@ -149,18 +171,25 @@ async def test_send_frame_success(mock_transport):
 @pytest.mark.asyncio
 async def test_send_frame_not_connected():
     transport = SatelBaseTransport("h", 1)
-    result = await transport.send_frame(b"x")
-    assert result is False
+
+    with pytest.raises(
+        SatelTransportDisconnectedError,
+        match="Cannot write a frame because the transport is not connected",
+    ):
+        await transport.send_frame(b"x")
 
 
 @pytest.mark.asyncio
 async def test_send_frame_failure(mock_transport):
-    mock_transport._writer.drain.side_effect = Exception("fail")
+    mock_transport._writer.drain.side_effect = ConnectionResetError("fail")
 
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(
+        SatelTransportDisconnectedError,
+        match="Transport connection was lost while writing a frame",
+    ) as excinfo:
         await mock_transport.send_frame(b"x")
 
-    assert "fail" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, ConnectionResetError)
     assert not mock_transport.connected
 
 
@@ -202,16 +231,31 @@ async def test_read_encrypted(encryption_handler, mock_encrypted_transport):
 
     encrypted_frame_length = 0xAA
     mock_encrypted_transport._reader.read.side_effect = [
-        bytes([encrypted_frame_length]),
-        b"some_encrypted_data",
+        bytes([encrypted_frame_length])
     ]
+    mock_encrypted_transport._reader.readexactly.return_value = b"some_encrypted_data"
 
     result = await mock_encrypted_transport.read_frame()
     assert result == decrypted_data + FRAME_END
-    mock_encrypted_transport._reader.read.assert_awaited_with(encrypted_frame_length)
+    mock_encrypted_transport._reader.readexactly.assert_awaited_with(
+        encrypted_frame_length
+    )
     encryption_handler_inst.extract_data_from_pdu.assert_called_with(
         b"some_encrypted_data"
     )
+
+
+@pytest.mark.asyncio
+async def test_read_encrypted_eof_raises_disconnected(mock_encrypted_transport):
+    mock_encrypted_transport._reader.read.return_value = b""
+
+    with pytest.raises(
+        SatelTransportDisconnectedError,
+        match="Transport connection was lost while reading encrypted frame length",
+    ):
+        await mock_encrypted_transport.read_frame()
+
+    assert not mock_encrypted_transport.connected
 
 
 @pytest.mark.asyncio

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from satel_integra.const import FRAME_END
+from satel_integra.exceptions import SatelConnectFailedError
 from satel_integra.transport import SatelBaseTransport, SatelEncryptedTransport
 
 
@@ -66,7 +67,13 @@ async def test_connect_failure(monkeypatch):
         asyncio, "open_connection", AsyncMock(side_effect=OSError("boom"))
     )
     transport = SatelBaseTransport("localhost", 1234)
-    await transport.connect()
+
+    with pytest.raises(
+        SatelConnectFailedError,
+        match="Unable to establish TCP connection to localhost:1234",
+    ):
+        await transport.connect()
+
     assert not transport.connected
 
 


### PR DESCRIPTION
This PR adds typed Satel exceptions to the library. There is a compatibility layer in place to make sure existing libraries can keep functioning without adjusting the code for now.

Most notable is the fact the `connect` method now indicates the exact (if known) reason why the connection failed.