### PR TITLE
Add exceptions to connection logic

### DIFF
--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -5,7 +5,12 @@ import logging
 
 from satel_integra.commands import SatelWriteCommand
 from satel_integra.const import MESSAGE_RESPONSE_TIMEOUT
-from satel_integra.exceptions import SatelConnectionStoppedError
+from satel_integra.exceptions import (
+    SatelConnectFailedError,
+    SatelConnectionInitializationError,
+    SatelConnectionStoppedError,
+    SatelPanelBusyError,
+)
 from satel_integra.messages import SatelWriteMessage
 from satel_integra.transport import (
     SatelBaseTransport,
@@ -58,50 +63,62 @@ class SatelConnection:
         if self.stopped:
             raise SatelConnectionStoppedError("Connection is stopped")
 
-    async def _connect(self, verify_connection: bool = True) -> bool:
+    async def _connect(self, verify_connection: bool = True) -> None:
         """Establish TCP connection. Must be called with _connection_lock held."""
         if self.stopped:
             _LOGGER.debug("Connection is closed, skipping connection")
-            return False
+            raise SatelConnectionStoppedError("Connection is stopped")
 
         if self.connected:
             _LOGGER.debug("Already connected, skipping connection")
-            return True
+            return
 
         _LOGGER.debug("Connecting to Satel Integra at %s:%s...", self._host, self._port)
 
-        if not await self._transport.connect():
-            _LOGGER.warning("Unable to establish TCP connection.")
+        try:
+            await self._transport.connect()
+        except SatelConnectFailedError:
+            _LOGGER.debug("Unable to establish TCP connection.")
             await self._close_locked(stop=False)
-            return False
+            raise
 
         if verify_connection:
             _LOGGER.debug("TCP connection established, verifying panel responsiveness")
-            if not await self._check_connection():
-                _LOGGER.warning(
+            try:
+                await self._check_connection()
+            except SatelPanelBusyError:
+                _LOGGER.debug(
                     "Connected to the panel, but it is not ready for use. "
                     "Another client may already be connected, or the panel may "
                     "still be busy."
                 )
                 await self._close_locked(stop=False)
-                return False
+                raise
+            except SatelConnectionInitializationError:
+                _LOGGER.debug(
+                    "Connected to the panel, but startup readiness validation failed."
+                )
+                await self._close_locked(stop=False)
+                raise
 
             _LOGGER.debug("TCP connection established, verifying protocol round-trip")
-            if not await self._verify_protocol():
-                _LOGGER.warning(
+            try:
+                await self._verify_protocol()
+            except SatelConnectionInitializationError:
+                _LOGGER.debug(
                     "Connected to the panel, but startup validation failed. "
                     "Check that the integration key and encryption settings match "
                     "the panel configuration."
                 )
                 await self._close_locked(stop=False)
-                return False
+                raise
 
         else:
             _LOGGER.debug(
                 "TCP connection established, skipping connection health check."
             )
 
-        _LOGGER.info("Connected to Satel Integra.")
+        _LOGGER.debug("Connected to Satel Integra.")
         # If we've had a successful connection before, this is a
         # reconnection — signal any waiters. Otherwise mark that we've
         # now had a connection so future connects can be treated as
@@ -110,9 +127,8 @@ class SatelConnection:
             self._reconnected_event.set()
 
         self._had_connection = True
-        return True
 
-    async def connect(self, verify_connection: bool = True) -> bool:
+    async def connect(self, verify_connection: bool = True) -> None:
         """Establish TCP connection with a single attempt (no retries).
 
         Acquires lock internally. Suitable for setup validation where a single
@@ -120,10 +136,10 @@ class SatelConnection:
         """
         async with self._connection_lock:
             if self.stopped:
-                return False
+                raise SatelConnectionStoppedError("Connection is stopped")
             if self.connected:
-                return True
-            return await self._connect(verify_connection=verify_connection)
+                return
+            await self._connect(verify_connection=verify_connection)
 
     async def read_frame(self) -> bytes | None:
         """Read a raw frame from the panel."""
@@ -146,13 +162,18 @@ class SatelConnection:
                 self._assert_not_stopped()
 
                 _LOGGER.debug("Not connected, attempting reconnection...")
-                success = await self._connect()
-
-            if success:
-                return
+                try:
+                    await self._connect()
+                    return
+                except (
+                    SatelConnectFailedError,
+                    SatelConnectionInitializationError,
+                    SatelPanelBusyError,
+                ):
+                    self._assert_not_stopped()
 
             self._assert_not_stopped()
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Connection failed, retrying in %ss...", self._reconnection_timeout
             )
             await asyncio.sleep(self._reconnection_timeout)
@@ -206,13 +227,15 @@ class SatelConnection:
         if stopped_waiter in done:
             self._assert_not_stopped()
 
-    async def _verify_protocol(self) -> bool:
+    async def _verify_protocol(self) -> None:
         """Verify that the panel accepts protocol frames on this transport."""
         if not self._transport.connected:
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Skipping protocol verification because the transport is not connected."
             )
-            return False
+            raise SatelConnectionInitializationError(
+                "Cannot verify protocol without an active transport connection"
+            )
 
         try:
             probe = SatelWriteMessage(SatelWriteCommand.RTC_AND_STATUS)
@@ -221,69 +244,85 @@ class SatelConnection:
             raw_response = await asyncio.wait_for(
                 self._transport.read_frame(), timeout=MESSAGE_RESPONSE_TIMEOUT
             )
+        except asyncio.TimeoutError as exc:
+            _LOGGER.debug(
+                "Startup protocol verification timed out after %ss while waiting "
+                "for the probe response.",
+                MESSAGE_RESPONSE_TIMEOUT,
+            )
+            raise SatelConnectionInitializationError(
+                "Panel did not respond to the startup protocol probe before timeout"
+            ) from exc
         except Exception as exc:
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Startup protocol verification failed while sending or reading "
                 "the probe response: %s",
                 exc,
                 exc_info=True,
             )
-            return False
+            raise SatelConnectionInitializationError(
+                "Panel did not complete startup protocol verification"
+            ) from exc
 
         if not raw_response:
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Startup protocol verification failed: no response received from the "
                 "panel."
             )
-            return False
+            raise SatelConnectionInitializationError(
+                "Panel did not respond to the startup protocol probe"
+            )
 
-        return True
-
-    async def _check_connection(self) -> bool:
+    async def _check_connection(self) -> None:
         """Check if the connection is valid and the panel is responsive."""
         if not self._transport.connected:
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Skipping connection check because the transport is not connected."
             )
-            return False
+            raise SatelConnectionInitializationError(
+                "Cannot validate the panel without an active transport connection"
+            )
 
         try:
             data = await asyncio.wait_for(
                 self._transport.read_initial_data(), timeout=0.1
             )
-
-            if data is None:
-                _LOGGER.info("Connection check failed: no initial data could be read.")
-                return False
-
-            # Satel returns a string starting with "Busy" when another client is connected
-            if b"Busy" in data:
-                _LOGGER.info(
-                    "Connection check failed: panel reports busy because another "
-                    "client is connected."
-                )
-                return False
-
-            # Log any other data to debug other potential blocking situation
-            _LOGGER.debug(
-                "Connection check received initial data after connect: %s", data
-            )
-
-            # Encrypted panels appear to return opaque bytes immediately when the
-            # session is already occupied. A healthy encrypted connection times out
-            # here instead.
-            if isinstance(self._transport, SatelEncryptedTransport) and data:
-                _LOGGER.info(
-                    "Connection check failed: encrypted panel returned unexpected "
-                    "initial data, so the session is treated as busy or unavailable."
-                )
-                return False
-
         except asyncio.TimeoutError:
             # Timeout is fine, it means we can actually read data
-            pass
+            return
         except Exception as exc:
             _LOGGER.debug("Connection check failed: %s", exc, exc_info=True)
-            return False
+            raise SatelConnectionInitializationError(
+                "Panel failed connection readiness checks"
+            ) from exc
 
-        return True
+        if data is None:
+            _LOGGER.debug("Connection check failed: no initial data could be read.")
+            raise SatelConnectionInitializationError(
+                "Panel did not provide initial data after connecting"
+            )
+
+        # Satel returns a string starting with "Busy" when another client is connected
+        if b"Busy" in data:
+            _LOGGER.debug(
+                "Connection check failed: panel reports busy because another "
+                "client is connected."
+            )
+            raise SatelPanelBusyError(
+                "Panel reports busy because another client is connected"
+            )
+
+        # Log any other data to debug other potential blocking situation
+        _LOGGER.debug("Connection check received initial data after connect: %s", data)
+
+        # Encrypted panels appear to return opaque bytes immediately when the
+        # session is already occupied. A healthy encrypted connection times out
+        # here instead.
+        if isinstance(self._transport, SatelEncryptedTransport) and data:
+            _LOGGER.debug(
+                "Connection check failed: encrypted panel returned unexpected "
+                "initial data, so the session is treated as busy or unavailable."
+            )
+            raise SatelPanelBusyError(
+                "Encrypted panel returned startup data indicating the session is busy"
+            )

--- a/satel_integra/exceptions.py
+++ b/satel_integra/exceptions.py
@@ -9,5 +9,21 @@ class SatelConnectionError(SatelIntegraError):
     """Raised when transport connection setup fails."""
 
 
+class SatelConnectFailedError(SatelConnectionError):
+    """Raised when the TCP connection to the panel cannot be established."""
+
+
+class SatelConnectionSetupError(SatelConnectionError):
+    """Raised when a TCP connection cannot be prepared for use."""
+
+
+class SatelPanelBusyError(SatelConnectionSetupError):
+    """Raised when the panel session is occupied by another client."""
+
+
+class SatelConnectionInitializationError(SatelConnectionSetupError):
+    """Raised when the panel does not complete connection setup successfully."""
+
+
 class SatelConnectionStoppedError(SatelConnectionError):
     """Raised when the connection has been terminally stopped."""

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -10,7 +10,12 @@ from warnings import warn
 
 from satel_integra.commands import SatelReadCommand, SatelWriteCommand
 from satel_integra.connection import SatelConnection
-from satel_integra.exceptions import SatelConnectionStoppedError
+from satel_integra.exceptions import (
+    SatelConnectFailedError,
+    SatelConnectionInitializationError,
+    SatelConnectionStoppedError,
+    SatelPanelBusyError,
+)
 from satel_integra.messages import SatelReadMessage, SatelWriteMessage
 from satel_integra.queue import SatelMessageQueue
 from satel_integra.utils import encode_bitmask_le
@@ -440,10 +445,16 @@ class AsyncSatel:
     async def connect(self, *, check_busy: bool = True) -> bool: ...
 
     @overload
-    async def connect(self, verify_connection: bool = True) -> bool: ...
+    async def connect(
+        self, verify_connection: bool = True, *, raise_exceptions: bool = False
+    ) -> bool: ...
 
     async def connect(
-        self, verify_connection: bool = True, *, check_busy: bool | None = None
+        self,
+        verify_connection: bool = True,
+        *,
+        check_busy: bool | None = None,
+        raise_exceptions: bool = False,
     ) -> bool:
         """Make a TCP connection to the alarm system."""
         if check_busy is not None:
@@ -454,7 +465,19 @@ class AsyncSatel:
             )
             verify_connection = check_busy
 
-        return await self._connection.connect(verify_connection=verify_connection)
+        try:
+            await self._connection.connect(verify_connection=verify_connection)
+        except (
+            SatelConnectFailedError,
+            SatelConnectionInitializationError,
+            SatelConnectionStoppedError,
+            SatelPanelBusyError,
+        ):
+            if raise_exceptions:
+                raise
+            return False
+
+        return True
 
     async def close(self):
         """Stop background tasks and close connection."""

--- a/satel_integra/transport.py
+++ b/satel_integra/transport.py
@@ -5,6 +5,7 @@ import logging
 
 from satel_integra.const import FRAME_END
 from satel_integra.encryption import EncryptedCommunicationHandler
+from satel_integra.exceptions import SatelConnectFailedError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,12 +39,14 @@ class SatelBaseTransport:
                 "TCP connection to %s:%s failed: %s", self._host, self._port, exc
             )
             await self.close()
-            return False
+            raise SatelConnectFailedError(
+                f"Unable to establish TCP connection to {self._host}:{self._port}"
+            ) from exc
 
     async def read_initial_data(self) -> bytes | None:
         """Read raw data available immediately after TCP connect."""
         if not self._reader:
-            _LOGGER.warning("Cannot read initial data, not connected.")
+            _LOGGER.debug("Cannot read initial data, not connected.")
             return None
 
         return await self._reader.read(-1)
@@ -51,7 +54,7 @@ class SatelBaseTransport:
     async def read_frame(self) -> bytes | None:
         """Template method for reading a frame from the panel."""
         if not self._reader:
-            _LOGGER.warning("Cannot read, not connected.")
+            _LOGGER.debug("Cannot read, not connected.")
             return None
 
         try:
@@ -67,12 +70,12 @@ class SatelBaseTransport:
                 _LOGGER.debug("Received raw frame: %s", frame.hex())
                 return frame
             else:
-                _LOGGER.warning("Read failed, no frame end marker found.")
+                _LOGGER.debug("Read failed, no frame end marker found.")
         except asyncio.IncompleteReadError:
             # Incomplete read due to connection closing
             pass
         except Exception as e:
-            _LOGGER.warning("Read failed: %s", e)
+            _LOGGER.debug("Read failed: %s", e)
 
         await self.close()
         return None
@@ -88,7 +91,7 @@ class SatelBaseTransport:
     async def send_frame(self, frame: bytes) -> bool:
         """Template method for writing a frame to the panel."""
         if not self._writer:
-            _LOGGER.warning("Cannot write, not connected.")
+            _LOGGER.debug("Cannot write, not connected.")
             return False
 
         try:
@@ -119,7 +122,7 @@ class SatelBaseTransport:
                 self._writer.close()
                 await self._writer.wait_closed()
             except Exception as e:
-                _LOGGER.warning("Exception during close: %s", e)
+                _LOGGER.debug("Exception during close: %s", e)
 
         self._reader = None
         self._writer = None
@@ -150,7 +153,7 @@ class SatelEncryptedTransport(SatelBaseTransport):
         """Read encrypted frame end decrypt it."""
 
         if not self._reader:
-            _LOGGER.warning("Cannot read, not connected.")
+            _LOGGER.debug("Cannot read, not connected.")
             return None
 
         # first byte tells about data length

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4,7 +4,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from satel_integra.connection import SatelConnection
-from satel_integra.exceptions import SatelConnectionStoppedError
+from satel_integra.exceptions import (
+    SatelConnectFailedError,
+    SatelConnectionInitializationError,
+    SatelConnectionStoppedError,
+    SatelPanelBusyError,
+)
 from satel_integra.transport import SatelEncryptedTransport
 
 
@@ -39,8 +44,7 @@ def mock_connection(mock_transport: AsyncMock) -> SatelConnection:
 
 @pytest.mark.asyncio
 async def test_connect_success(mock_connection, mock_transport):
-    result = await mock_connection.connect()
-    assert result is True
+    await mock_connection.connect()
 
     mock_transport.connect.assert_awaited_once()
     mock_transport.read_initial_data.assert_awaited_once()
@@ -50,95 +54,105 @@ async def test_connect_success(mock_connection, mock_transport):
 
 
 @pytest.mark.asyncio
-async def test_connect_config_failure(mock_connection, mock_transport):
-    mock_transport.connect.side_effect = [False]
+async def test_connect_config_failure_raises(mock_connection, mock_transport):
+    mock_transport.connect.side_effect = SatelConnectFailedError("boom")
 
-    result = await mock_connection.connect()
-    assert result is False
+    with pytest.raises(SatelConnectFailedError, match="boom"):
+        await mock_connection.connect()
+
     assert mock_connection.stopped is False
-
     mock_transport.connect.assert_awaited_once()
-    mock_transport.read_initial_data.assert_not_awaited()
+    mock_transport.close.assert_awaited_once()
     mock_transport.send_frame.assert_not_awaited()
     mock_transport.read_frame.assert_not_awaited()
-    mock_transport.close.assert_awaited_once()
+    mock_transport.read_initial_data.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_connect_device_busy_failure(mock_connection, mock_transport):
+async def test_connect_device_busy_raises(mock_connection, mock_transport):
     mock_transport.read_initial_data.return_value = b"Busy!\r\n"
 
-    result = await mock_connection.connect()
-    assert result is False
-    assert mock_connection.stopped is False
+    with pytest.raises(
+        SatelPanelBusyError,
+        match="Panel reports busy because another client is connected",
+    ):
+        await mock_connection.connect()
 
-    mock_transport.read_initial_data.assert_awaited_once()
+    assert mock_connection.stopped is False
+    mock_transport.connect.assert_awaited_once()
     mock_transport.close.assert_awaited_once()
     mock_transport.send_frame.assert_not_awaited()
     mock_transport.read_frame.assert_not_awaited()
+    mock_transport.read_initial_data.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_connect_readiness_failure_closes_connection(
+    mock_connection, mock_transport
+):
+    mock_transport.read_initial_data.return_value = None
+
+    with pytest.raises(
+        SatelConnectionInitializationError,
+        match="Panel did not provide initial data after connecting",
+    ):
+        await mock_connection.connect()
+
+    assert mock_connection.stopped is False
+    mock_transport.connect.assert_awaited_once()
+    mock_transport.close.assert_awaited_once()
+    mock_transport.send_frame.assert_not_awaited()
+    mock_transport.read_frame.assert_not_awaited()
+    mock_transport.read_initial_data.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_connect_can_skip_startup_verification(mock_connection, mock_transport):
-    result = await mock_connection.connect(verify_connection=False)
+    await mock_connection.connect(verify_connection=False)
 
-    assert result is True
+    mock_transport.connect.assert_awaited_once()
+    mock_transport.close.assert_not_awaited()
     mock_transport.read_initial_data.assert_not_awaited()
     mock_transport.send_frame.assert_not_awaited()
     mock_transport.read_frame.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_connect_protocol_probe_failure_closes_connection(
-    mock_connection, mock_transport
-):
+async def test_connect_protocol_probe_failure_raises(mock_connection, mock_transport):
     mock_transport.read_frame.return_value = None
 
-    result = await mock_connection.connect()
+    with pytest.raises(
+        SatelConnectionInitializationError,
+        match="Panel did not respond to the startup protocol probe",
+    ):
+        await mock_connection.connect()
 
-    assert result is False
     assert mock_connection.stopped is False
-
     mock_transport.send_frame.assert_awaited_once()
     mock_transport.read_frame.assert_awaited_once()
     mock_transport.close.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_connect_protocol_probe_timeout_closes_connection(
-    mock_connection, mock_transport
-):
+async def test_connect_protocol_probe_timeout_raises(mock_connection, mock_transport):
     mock_transport.read_frame.side_effect = asyncio.TimeoutError
 
-    result = await mock_connection.connect()
+    with pytest.raises(
+        SatelConnectionInitializationError,
+        match="Panel did not respond to the startup protocol probe before timeout",
+    ):
+        await mock_connection.connect()
 
-    assert result is False
     assert mock_connection.stopped is False
     mock_transport.close.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_connect_skips_startup_validation_when_disabled(
-    mock_connection, mock_transport
-):
-    mock_transport.read_initial_data.return_value = b"Busy!\r\n"
-
-    result = await mock_connection.connect(verify_connection=False)
-    assert result is True
-
-    mock_transport.connect.assert_awaited_once()
-    mock_transport.read_initial_data.assert_not_awaited()
-    mock_transport.send_frame.assert_not_awaited()
-    mock_transport.read_frame.assert_not_awaited()
-    mock_transport.close.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_connect_skipped_when_stopped(mock_connection, mock_transport):
+async def test_connect_raises_when_stopped(mock_connection, mock_transport):
     mock_connection._stopped = True
 
-    result = await mock_connection.connect()
-    assert result is False
+    with pytest.raises(SatelConnectionStoppedError, match="Connection is stopped"):
+        await mock_connection.connect()
 
     mock_transport.connect.assert_not_awaited()
     mock_transport.read_initial_data.assert_not_awaited()
@@ -171,7 +185,7 @@ async def test_ensure_connected_retries_after_transient_connect_failure(
         attempts += 1
         if attempts == 1:
             mock_transport.connected = False
-            return False
+            raise SatelConnectFailedError("boom")
 
         mock_transport.connected = True
         return True
@@ -200,23 +214,29 @@ async def test_check_connection_read_exception(mock_connection, mock_transport):
     mock_transport.connected = True
     mock_transport.read_initial_data.side_effect = Exception("boom")
 
-    result = await mock_connection._check_connection()
+    with pytest.raises(
+        SatelConnectionInitializationError,
+        match="Panel failed connection readiness checks",
+    ):
+        await mock_connection._check_connection()
 
-    assert result is False
     assert mock_connection.stopped is False
     mock_transport.close.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_check_connection_returns_false_when_initial_read_unavailable(
+async def test_check_connection_raises_when_initial_read_unavailable(
     mock_connection, mock_transport
 ):
     mock_transport.connected = True
     mock_transport.read_initial_data.return_value = None
 
-    result = await mock_connection._check_connection()
+    with pytest.raises(
+        SatelConnectionInitializationError,
+        match="Panel did not provide initial data after connecting",
+    ):
+        await mock_connection._check_connection()
 
-    assert result is False
     mock_transport.close.assert_not_awaited()
 
 
@@ -233,9 +253,12 @@ async def test_encrypted_check_connection_treats_unexpected_data_as_busy(
     mock_connection._transport._reader = object()
     mock_connection._transport._writer = object()
 
-    result = await mock_connection._check_connection()
+    with pytest.raises(
+        SatelPanelBusyError,
+        match="Encrypted panel returned startup data indicating the session is busy",
+    ):
+        await mock_connection._check_connection()
 
-    assert result is False
     mock_transport.close.assert_not_awaited()
 
 
@@ -257,7 +280,7 @@ async def test_encrypted_check_connection_timeout_is_healthy(
 
     result = await mock_connection._check_connection()
 
-    assert result is True
+    assert result is None
     mock_transport.close.assert_not_awaited()
 
 
@@ -275,7 +298,7 @@ async def test_close_success(mock_connection, mock_transport):
 async def test_close_already_stopped(mock_connection, mock_transport):
     mock_connection._stopped = True
 
-    await mock_connection.close()  # should not raise or call anything
+    await mock_connection.close()
 
     mock_transport.close.assert_not_awaited()
 
@@ -284,25 +307,12 @@ async def test_close_already_stopped(mock_connection, mock_transport):
 async def test_reconnection_event_set_on_subsequent_connect(
     mock_connection, mock_transport
 ):
-    """First successful connect should set `_had_connection` but not the event.
+    await mock_connection.connect()
 
-    A subsequent successful connect should set the `_reconnected_event` so
-    waiters are notified.
-    """
-    # First connect (initial connection)
-    result = await mock_connection.connect()
-    assert result is True
-
-    # After initial connect, we have had a connection but the reconnection
-    # event should not be set.
     assert mock_connection._had_connection is True
     assert mock_connection._reconnected_event.is_set() is False
 
-    # Ensure the event is cleared, then call connect() again to simulate a
-    # subsequent reconnection — the event should be set this time.
     mock_connection._reconnected_event.clear()
-
-    # Simulate disconnected state at start of second connect
     mock_transport.connected = False
 
     await mock_connection.connect()
@@ -314,17 +324,10 @@ async def test_reconnection_event_set_on_subsequent_connect(
 async def test_wait_reconnected_blocks_and_returns_true(
     mock_connection, mock_transport
 ):
-    """`wait_reconnected()` should block until `_reconnected_event` is set."""
-    # Ensure we've had an initial connection so wait_reconnected will wait for
-    # a later reconnection.
     await mock_connection.connect()
 
     waiter = asyncio.create_task(mock_connection.wait_reconnected())
-
-    # Give the loop a tick so the waiter can clear the event and start waiting
     await asyncio.sleep(0)
-
-    # Now signal reconnection and await the waiter result
     mock_connection._reconnected_event.set()
 
     await asyncio.wait_for(waiter, timeout=1.0)

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -4,7 +4,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from satel_integra.exceptions import SatelConnectionStoppedError
+from satel_integra.exceptions import (
+    SatelConnectFailedError,
+    SatelConnectionInitializationError,
+    SatelConnectionStoppedError,
+    SatelPanelBusyError,
+)
 from satel_integra.satel_integra import AlarmState, AsyncSatel
 
 
@@ -288,4 +293,45 @@ async def test_watch_connection_stopped_stops_queue_and_tasks(satel):
 async def test_connect_passes_verify_connection_flag(satel, mock_connection):
     await satel.connect(verify_connection=False)
 
-    mock_connection.connect.assert_awaited_once_with(verify_connection=False)
+    mock_connection.connect.assert_awaited_once_with(
+        verify_connection=False,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exc_type",
+    [
+        SatelConnectFailedError,
+        SatelPanelBusyError,
+        SatelConnectionInitializationError,
+        SatelConnectionStoppedError,
+    ],
+)
+async def test_connect_returns_false_in_compat_mode_for_connect_exceptions(
+    satel, mock_connection, exc_type
+):
+    mock_connection.connect.side_effect = exc_type("boom")
+
+    result = await satel.connect()
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exc_type",
+    [
+        SatelConnectFailedError,
+        SatelPanelBusyError,
+        SatelConnectionInitializationError,
+        SatelConnectionStoppedError,
+    ],
+)
+async def test_connect_raises_in_strict_mode_for_connect_exceptions(
+    satel, mock_connection, exc_type
+):
+    mock_connection.connect.side_effect = exc_type("boom")
+
+    with pytest.raises(exc_type, match="boom"):
+        await satel.connect(raise_exceptions=True)

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from satel_integra.const import FRAME_END
+from satel_integra.exceptions import SatelConnectFailedError
 from satel_integra.transport import SatelBaseTransport, SatelEncryptedTransport
 
 
@@ -66,7 +67,13 @@ async def test_connect_failure(monkeypatch):
         asyncio, "open_connection", AsyncMock(side_effect=OSError("boom"))
     )
     transport = SatelBaseTransport("localhost", 1234)
-    await transport.connect()
+
+    with pytest.raises(
+        SatelConnectFailedError,
+        match="Unable to establish TCP connection to localhost:1234",
+    ):
+        await transport.connect()
+
     assert not transport.connected
 
 
@@ -84,7 +91,7 @@ async def test_read_initial_data(mock_transport):
 async def test_read_initial_data_not_connected(caplog):
     transport = SatelBaseTransport("h", 1)
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.DEBUG):
         result = await transport.read_initial_data()
 
     assert result is None


### PR DESCRIPTION
This PR adds exceptions to the connection logic, allowing calling code to handle the specific cases (like panel busy or incorrect encryption key).

A backwards compatible method is added to allow existing code to function. Future versions will default the exception raising to True and eventually remove the boolean return path