### PR TITLE
Add connection callback

### DIFF
--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -3,8 +3,6 @@
 import asyncio
 import logging
 from collections.abc import Callable
-from functools import wraps
-from typing import Any
 
 from satel_integra.commands import SatelWriteCommand
 from satel_integra.const import MESSAGE_RESPONSE_TIMEOUT
@@ -22,21 +20,6 @@ from satel_integra.transport import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def notify_connection_state(
-    fn: Callable[..., Any],
-) -> Callable[..., Any]:
-    """Notify connection status callback after connection-touching methods."""
-
-    @wraps(fn)
-    async def wrapper(self, *args, **kwargs):
-        try:
-            return await fn(self, *args, **kwargs)
-        finally:
-            self._notify_connection_status_changed()
-
-    return wrapper
 
 
 class SatelConnection:
@@ -65,8 +48,6 @@ class SatelConnection:
             asyncio.Event()
         )  # Signals when connection is re-established
         self._had_connection = False
-        self._connection_status_callback: Callable[[bool], None] | None = None
-        self._last_connected_state = self.connected
 
     @property
     def connected(self) -> bool:
@@ -83,11 +64,11 @@ class SatelConnection:
         if self.stopped:
             raise SatelConnectionStoppedError("Connection is stopped")
 
-    def set_connection_status_callback(
-        self, callback: Callable[[bool], None] | None
+    def add_connection_state_callback(
+        self, callback: Callable[[], None] | None
     ) -> None:
         """Register callback called when connection status changes."""
-        self._connection_status_callback = callback
+        self._transport.add_connection_state_callback(callback)
 
     def _notify_connection_status_changed(self) -> None:
         """Notify when connected status changes."""
@@ -105,7 +86,6 @@ class SatelConnection:
         except Exception as exc:
             _LOGGER.exception("Error in connection status callback: %s", exc)
 
-    @notify_connection_state
     async def _connect(self, verify_connection: bool = True) -> None:
         """Establish TCP connection. Must be called with _connection_lock held."""
         if self.stopped:
@@ -184,12 +164,10 @@ class SatelConnection:
                 return
             await self._connect(verify_connection=verify_connection)
 
-    @notify_connection_state
     async def read_frame(self) -> bytes | None:
         """Read a raw frame from the panel."""
         return await self._transport.read_frame()
 
-    @notify_connection_state
     async def send_frame(self, frame: bytes) -> bool:
         """Send a raw frame to the panel."""
         return await self._transport.send_frame(frame)
@@ -243,7 +221,6 @@ class SatelConnection:
 
         await self._stopped_event.wait()
 
-    @notify_connection_state
     async def close(self) -> None:
         """Close the connection gracefully and clean up."""
         async with self._connection_lock:

--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -2,6 +2,9 @@
 
 import asyncio
 import logging
+from collections.abc import Callable
+from functools import wraps
+from typing import Any
 
 from satel_integra.commands import SatelWriteCommand
 from satel_integra.const import MESSAGE_RESPONSE_TIMEOUT
@@ -19,6 +22,21 @@ from satel_integra.transport import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def notify_connection_state(
+    fn: Callable[..., Any],
+) -> Callable[..., Any]:
+    """Notify connection status callback after connection-touching methods."""
+
+    @wraps(fn)
+    async def wrapper(self, *args, **kwargs):
+        try:
+            return await fn(self, *args, **kwargs)
+        finally:
+            self._notify_connection_status_changed()
+
+    return wrapper
 
 
 class SatelConnection:
@@ -47,6 +65,8 @@ class SatelConnection:
             asyncio.Event()
         )  # Signals when connection is re-established
         self._had_connection = False
+        self._connection_status_callback: Callable[[bool], None] | None = None
+        self._last_connected_state = self.connected
 
     @property
     def connected(self) -> bool:
@@ -63,6 +83,29 @@ class SatelConnection:
         if self.stopped:
             raise SatelConnectionStoppedError("Connection is stopped")
 
+    def set_connection_status_callback(
+        self, callback: Callable[[bool], None] | None
+    ) -> None:
+        """Register callback called when connection status changes."""
+        self._connection_status_callback = callback
+
+    def _notify_connection_status_changed(self) -> None:
+        """Notify when connected status changes."""
+        current_state = self.connected
+        if current_state == self._last_connected_state:
+            return
+
+        self._last_connected_state = current_state
+        callback = self._connection_status_callback
+        if callback is None:
+            return
+
+        try:
+            callback(current_state)
+        except Exception as exc:
+            _LOGGER.exception("Error in connection status callback: %s", exc)
+
+    @notify_connection_state
     async def _connect(self, verify_connection: bool = True) -> None:
         """Establish TCP connection. Must be called with _connection_lock held."""
         if self.stopped:
@@ -141,10 +184,12 @@ class SatelConnection:
                 return
             await self._connect(verify_connection=verify_connection)
 
+    @notify_connection_state
     async def read_frame(self) -> bytes | None:
         """Read a raw frame from the panel."""
         return await self._transport.read_frame()
 
+    @notify_connection_state
     async def send_frame(self, frame: bytes) -> bool:
         """Send a raw frame to the panel."""
         return await self._transport.send_frame(frame)
@@ -198,6 +243,7 @@ class SatelConnection:
 
         await self._stopped_event.wait()
 
+    @notify_connection_state
     async def close(self) -> None:
         """Close the connection gracefully and clean up."""
         async with self._connection_lock:

--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from collections.abc import Callable, Awaitable
+from collections.abc import Awaitable, Callable
 
 from satel_integra.commands import SatelWriteCommand
 from satel_integra.const import MESSAGE_RESPONSE_TIMEOUT

--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Awaitable
 
 from satel_integra.commands import SatelWriteCommand
 from satel_integra.const import MESSAGE_RESPONSE_TIMEOUT
@@ -65,7 +65,7 @@ class SatelConnection:
             raise SatelConnectionStoppedError("Connection is stopped")
 
     def add_connection_state_callback(
-        self, callback: Callable[[], None] | None
+        self, callback: Callable[[], Awaitable[None]]
     ) -> None:
         """Register callback called when connection status changes."""
         self._transport.add_connection_state_callback(callback)

--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -2,10 +2,9 @@
 
 import asyncio
 import logging
-from collections.abc import Callable
 
 from satel_integra.commands import SatelWriteCommand
-from satel_integra.const import MESSAGE_RESPONSE_TIMEOUT
+from satel_integra.const import MESSAGE_RESPONSE_TIMEOUT, ConnectionStateCallback
 from satel_integra.exceptions import (
     SatelConnectFailedError,
     SatelConnectionInitializationError,
@@ -64,25 +63,9 @@ class SatelConnection:
         if self.stopped:
             raise SatelConnectionStoppedError("Connection is stopped")
 
-    def add_connection_state_callback(self, callback: Callable[[], None]) -> None:
+    def add_connection_state_callback(self, callback: ConnectionStateCallback) -> None:
         """Register callback called when connection status changes."""
         self._transport.add_connection_state_callback(callback)
-
-    def _notify_connection_status_changed(self) -> None:
-        """Notify when connected status changes."""
-        current_state = self.connected
-        if current_state == self._last_connected_state:
-            return
-
-        self._last_connected_state = current_state
-        callback = self._connection_status_callback
-        if callback is None:
-            return
-
-        try:
-            callback(current_state)
-        except Exception as exc:
-            _LOGGER.exception("Error in connection status callback: %s", exc)
 
     async def _connect(self, verify_connection: bool = True) -> None:
         """Establish TCP connection. Must be called with _connection_lock held."""

--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 
 from satel_integra.commands import SatelWriteCommand
 from satel_integra.const import MESSAGE_RESPONSE_TIMEOUT
@@ -64,9 +64,7 @@ class SatelConnection:
         if self.stopped:
             raise SatelConnectionStoppedError("Connection is stopped")
 
-    def add_connection_state_callback(
-        self, callback: Callable[[], Awaitable[None]]
-    ) -> None:
+    def add_connection_state_callback(self, callback: Callable[[], None]) -> None:
         """Register callback called when connection status changes."""
         self._transport.add_connection_state_callback(callback)
 

--- a/satel_integra/const.py
+++ b/satel_integra/const.py
@@ -1,5 +1,7 @@
 """Constants for the Satel Integra integration."""
 
+from collections.abc import Awaitable, Callable
+
 FRAME_START = bytes([0xFE, 0xFE])
 FRAME_END = bytes([0xFE, 0x0D])
 
@@ -7,3 +9,5 @@ FRAME_SPECIAL_BYTES = bytes([0xFE])
 FRAME_SPECIAL_BYTES_REPLACEMENT = bytes([0xFE, 0xF0])
 
 MESSAGE_RESPONSE_TIMEOUT = 5
+
+ConnectionStateCallback = Callable[[], None | Awaitable[None]]

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -347,7 +347,6 @@ class AsyncSatel:
         alarm_status_callback: Callable[[], None] | None = None,
         zone_changed_callback: Callable[[dict[int, int]], None] | None = None,
         output_changed_callback: Callable[[dict[int, int]], None] | None = None,
-        connection_status_changed_callback: Callable[[bool], None] | None = None,
     ):
         """Register callback handlers for events."""
         if alarm_status_callback:
@@ -356,10 +355,10 @@ class AsyncSatel:
             self._zone_changed_callback = zone_changed_callback
         if output_changed_callback:
             self._output_changed_callback = output_changed_callback
-        if connection_status_changed_callback:
-            self._connection.set_connection_status_callback(
-                connection_status_changed_callback
-            )
+
+    def add_connection_status_callback(self, callback: Callable[[], None]) -> None:
+        """Add a callback to be called when connection status changes."""
+        self._connection.add_connection_state_callback(callback)
 
     # endregion
 

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -356,7 +356,9 @@ class AsyncSatel:
         if output_changed_callback:
             self._output_changed_callback = output_changed_callback
 
-    def add_connection_status_callback(self, callback: Callable[[], None]) -> None:
+    def add_connection_status_callback(
+        self, callback: Callable[[], Awaitable[None]]
+    ) -> None:
         """Add a callback to be called when connection status changes."""
         self._connection.add_connection_state_callback(callback)
 

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -10,6 +10,7 @@ from warnings import warn
 
 from satel_integra.commands import SatelReadCommand, SatelWriteCommand
 from satel_integra.connection import SatelConnection
+from satel_integra.const import ConnectionStateCallback
 from satel_integra.exceptions import (
     SatelConnectFailedError,
     SatelConnectionInitializationError,
@@ -356,7 +357,7 @@ class AsyncSatel:
         if output_changed_callback:
             self._output_changed_callback = output_changed_callback
 
-    def add_connection_status_callback(self, callback: Callable[[], None]) -> None:
+    def add_connection_status_callback(self, callback: ConnectionStateCallback) -> None:
         """Add a callback to be called when connection status changes."""
         self._connection.add_connection_state_callback(callback)
 

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -347,6 +347,7 @@ class AsyncSatel:
         alarm_status_callback: Callable[[], None] | None = None,
         zone_changed_callback: Callable[[dict[int, int]], None] | None = None,
         output_changed_callback: Callable[[dict[int, int]], None] | None = None,
+        connection_status_changed_callback: Callable[[bool], None] | None = None,
     ):
         """Register callback handlers for events."""
         if alarm_status_callback:
@@ -355,6 +356,10 @@ class AsyncSatel:
             self._zone_changed_callback = zone_changed_callback
         if output_changed_callback:
             self._output_changed_callback = output_changed_callback
+        if connection_status_changed_callback:
+            self._connection.set_connection_status_callback(
+                connection_status_changed_callback
+            )
 
     # endregion
 

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -356,9 +356,7 @@ class AsyncSatel:
         if output_changed_callback:
             self._output_changed_callback = output_changed_callback
 
-    def add_connection_status_callback(
-        self, callback: Callable[[], Awaitable[None]]
-    ) -> None:
+    def add_connection_status_callback(self, callback: Callable[[], None]) -> None:
         """Add a callback to be called when connection status changes."""
         self._connection.add_connection_state_callback(callback)
 

--- a/satel_integra/transport.py
+++ b/satel_integra/transport.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from collections.abc import Callable, Awaitable
 
 from satel_integra.const import FRAME_END
 from satel_integra.encryption import EncryptedCommunicationHandler
@@ -19,16 +20,34 @@ class SatelBaseTransport:
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
 
+        self._connection_event = asyncio.Event()
+        self._connection_state_callbacks: list[Callable[[], Awaitable[None]]] = []
+        self._last_connected_state = False
+
     @property
     def connected(self) -> bool:
         """Return True if connected to the panel."""
         return self._reader is not None and self._writer is not None
+
+    def add_connection_state_callback(self, callback: Callable[[], None]) -> None:
+        """Add a callback to be called when transport connection status changes."""
+        self._connection_state_callbacks.append(callback)
+
+    def _notify_connection_state_changed(self, connected: bool) -> None:
+        """Invoke callback when connection state changes."""
+        if connected == self._last_connected_state:
+            return
+
+        self._last_connected_state = connected
+        for callback in self._connection_state_callbacks:
+            await callback()
 
     def _reset_connection(self) -> None:
         """Reset transport connection handles and clear connection event."""
         self._connection_event.clear()
         self._reader = None
         self._writer = None
+        self._notify_connection_state_changed(False)
 
     async def connect(self) -> bool:
         """Establish TCP connection."""
@@ -39,6 +58,8 @@ class SatelBaseTransport:
             )
             _LOGGER.debug("TCP connection established to %s:%s", self._host, self._port)
             return True
+            self._connection_event.set()
+            self._notify_connection_state_changed(True)
 
         except Exception as exc:
             _LOGGER.debug(

--- a/satel_integra/transport.py
+++ b/satel_integra/transport.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Awaitable
 
 from satel_integra.const import FRAME_END
 from satel_integra.encryption import EncryptedCommunicationHandler
@@ -21,7 +21,7 @@ class SatelBaseTransport:
         self._writer: asyncio.StreamWriter | None = None
 
         self._connection_event = asyncio.Event()
-        self._connection_state_callbacks: list[Callable[[], None]] = []
+        self._connection_state_callbacks: list[Callable[[], Awaitable[None]]] = []
         self._last_connected_state = False
 
     @property
@@ -29,7 +29,9 @@ class SatelBaseTransport:
         """Return True if connected to the panel."""
         return self._reader is not None and self._writer is not None
 
-    def add_connection_state_callback(self, callback: Callable[[], None]) -> None:
+    def add_connection_state_callback(
+        self, callback: Callable[[], Awaitable[None]]
+    ) -> None:
         """Add a callback to be called when transport connection status changes."""
         self._connection_state_callbacks.append(callback)
 
@@ -40,7 +42,7 @@ class SatelBaseTransport:
 
         self._last_connected_state = connected
         for callback in self._connection_state_callbacks:
-            callback()
+            await callback()
 
     def _reset_connection(self) -> None:
         """Reset transport connection handles and clear connection event."""

--- a/satel_integra/transport.py
+++ b/satel_integra/transport.py
@@ -48,9 +48,12 @@ class SatelBaseTransport:
     async def _notify_connection_state_changed(self) -> None:
         """Invoke callback when connection state changes."""
         for callback in self._connection_state_callbacks:
-            result = callback()
-            if inspect.isawaitable(result):
-                await result
+            try:
+                result = callback()
+                if inspect.isawaitable(result):
+                    await result
+            except Exception as exc:
+                _LOGGER.exception("Error in connection state callback: %s", exc)
 
     async def _reset_connection(self) -> None:
         """Reset transport connection handles and clear connection event."""

--- a/satel_integra/transport.py
+++ b/satel_integra/transport.py
@@ -181,9 +181,9 @@ class SatelEncryptedTransport(SatelBaseTransport):
         self._encryption_handler: EncryptedCommunicationHandler
         super().__init__(host, port)
 
-    async def connect(self) -> bool:
+    async def connect(self) -> None:
         self._encryption_handler = EncryptedCommunicationHandler(self._integration_key)
-        return await super().connect()
+        await super().connect()
 
     async def _read_from_transport(self) -> bytes | None:
         """Read encrypted frame end decrypt it."""

--- a/satel_integra/transport.py
+++ b/satel_integra/transport.py
@@ -53,7 +53,7 @@ class SatelBaseTransport:
         self._writer = None
         await self._set_connection_state(False)
 
-    async def connect(self) -> bool:
+    async def connect(self) -> None:
         """Establish TCP connection."""
 
         try:

--- a/satel_integra/transport.py
+++ b/satel_integra/transport.py
@@ -22,7 +22,6 @@ class SatelBaseTransport:
 
         self._connection_event = asyncio.Event()
         self._connection_state_callbacks: list[Callable[[], Awaitable[None]]] = []
-        self._last_connected_state = False
 
     @property
     def connected(self) -> bool:
@@ -35,21 +34,24 @@ class SatelBaseTransport:
         """Add a callback to be called when transport connection status changes."""
         self._connection_state_callbacks.append(callback)
 
-    def _notify_connection_state_changed(self, connected: bool) -> None:
-        """Invoke callback when connection state changes."""
-        if connected == self._last_connected_state:
-            return
+    async def _set_connection_state(self, connected: bool) -> None:
+        """Set the connection event and notify callbacks."""
+        if connected:
+            self._connection_event.set()
+        else:
+            self._connection_event.clear()
+        await self._notify_connection_state_changed()
 
-        self._last_connected_state = connected
+    async def _notify_connection_state_changed(self) -> None:
+        """Invoke callback when connection state changes."""
         for callback in self._connection_state_callbacks:
             await callback()
 
-    def _reset_connection(self) -> None:
+    async def _reset_connection(self) -> None:
         """Reset transport connection handles and clear connection event."""
-        self._connection_event.clear()
         self._reader = None
         self._writer = None
-        self._notify_connection_state_changed(False)
+        await self._set_connection_state(False)
 
     async def connect(self) -> bool:
         """Establish TCP connection."""
@@ -59,9 +61,7 @@ class SatelBaseTransport:
                 self._host, self._port
             )
             _LOGGER.debug("TCP connection established to %s:%s", self._host, self._port)
-            return True
-            self._connection_event.set()
-            self._notify_connection_state_changed(True)
+            await self._set_connection_state(True)
 
         except Exception as exc:
             _LOGGER.debug(
@@ -153,7 +153,7 @@ class SatelBaseTransport:
             except Exception as e:
                 _LOGGER.debug("Exception during close: %s", e)
 
-        self._reset_connection()
+        await self._reset_connection()
 
 
 class SatelPlainTransport(SatelBaseTransport):

--- a/satel_integra/transport.py
+++ b/satel_integra/transport.py
@@ -1,10 +1,10 @@
 """Connection management for Satel Integra panel."""
 
 import asyncio
+import inspect
 import logging
-from collections.abc import Callable
 
-from satel_integra.const import FRAME_END
+from satel_integra.const import FRAME_END, ConnectionStateCallback
 from satel_integra.encryption import EncryptedCommunicationHandler
 from satel_integra.exceptions import SatelConnectFailedError
 
@@ -21,14 +21,14 @@ class SatelBaseTransport:
         self._writer: asyncio.StreamWriter | None = None
 
         self._connection_event = asyncio.Event()
-        self._connection_state_callbacks: list[Callable[[], None]] = []
+        self._connection_state_callbacks: list[ConnectionStateCallback] = []
 
     @property
     def connected(self) -> bool:
         """Return True if connected to the panel."""
         return self._reader is not None and self._writer is not None
 
-    def add_connection_state_callback(self, callback: Callable[[], None]) -> None:
+    def add_connection_state_callback(self, callback: ConnectionStateCallback) -> None:
         """Add a callback to be called when transport connection status changes."""
         self._connection_state_callbacks.append(callback)
 
@@ -43,7 +43,9 @@ class SatelBaseTransport:
     async def _notify_connection_state_changed(self) -> None:
         """Invoke callback when connection state changes."""
         for callback in self._connection_state_callbacks:
-            await callback()
+            result = callback()
+            if inspect.isawaitable(result):
+                await result
 
     async def _reset_connection(self) -> None:
         """Reset transport connection handles and clear connection event."""

--- a/satel_integra/transport.py
+++ b/satel_integra/transport.py
@@ -24,6 +24,12 @@ class SatelBaseTransport:
         """Return True if connected to the panel."""
         return self._reader is not None and self._writer is not None
 
+    def _reset_connection(self) -> None:
+        """Reset transport connection handles and clear connection event."""
+        self._connection_event.clear()
+        self._reader = None
+        self._writer = None
+
     async def connect(self) -> bool:
         """Establish TCP connection."""
 
@@ -124,8 +130,7 @@ class SatelBaseTransport:
             except Exception as e:
                 _LOGGER.debug("Exception during close: %s", e)
 
-        self._reader = None
-        self._writer = None
+        self._reset_connection()
 
 
 class SatelPlainTransport(SatelBaseTransport):

--- a/satel_integra/transport.py
+++ b/satel_integra/transport.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from collections.abc import Callable, Awaitable
+from collections.abc import Callable
 
 from satel_integra.const import FRAME_END
 from satel_integra.encryption import EncryptedCommunicationHandler
@@ -21,7 +21,7 @@ class SatelBaseTransport:
         self._writer: asyncio.StreamWriter | None = None
 
         self._connection_event = asyncio.Event()
-        self._connection_state_callbacks: list[Callable[[], Awaitable[None]]] = []
+        self._connection_state_callbacks: list[Callable[[], None]] = []
         self._last_connected_state = False
 
     @property
@@ -40,7 +40,7 @@ class SatelBaseTransport:
 
         self._last_connected_state = connected
         for callback in self._connection_state_callbacks:
-            await callback()
+            callback()
 
     def _reset_connection(self) -> None:
         """Reset transport connection handles and clear connection event."""

--- a/satel_integra/transport.py
+++ b/satel_integra/transport.py
@@ -34,10 +34,15 @@ class SatelBaseTransport:
 
     async def _set_connection_state(self, connected: bool) -> None:
         """Set the connection event and notify callbacks."""
+        was_connected = self._connection_event.is_set()
+        if connected == was_connected:
+            return
+
         if connected:
             self._connection_event.set()
         else:
             self._connection_event.clear()
+
         await self._notify_connection_state_changed()
 
     async def _notify_connection_state_changed(self) -> None:

--- a/satel_integra/transport.py
+++ b/satel_integra/transport.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from collections.abc import Callable, Awaitable
+from collections.abc import Callable
 
 from satel_integra.const import FRAME_END
 from satel_integra.encryption import EncryptedCommunicationHandler
@@ -21,16 +21,14 @@ class SatelBaseTransport:
         self._writer: asyncio.StreamWriter | None = None
 
         self._connection_event = asyncio.Event()
-        self._connection_state_callbacks: list[Callable[[], Awaitable[None]]] = []
+        self._connection_state_callbacks: list[Callable[[], None]] = []
 
     @property
     def connected(self) -> bool:
         """Return True if connected to the panel."""
         return self._reader is not None and self._writer is not None
 
-    def add_connection_state_callback(
-        self, callback: Callable[[], Awaitable[None]]
-    ) -> None:
+    def add_connection_state_callback(self, callback: Callable[[], None]) -> None:
         """Add a callback to be called when transport connection status changes."""
         self._connection_state_callbacks.append(callback)
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -365,13 +365,13 @@ async def test_connection_status_callback_called_on_connect(
     mock_connection, mock_transport
 ):
     callback = MagicMock()
-    mock_connection.add_connection_status_callback(callback)
+    mock_connection.add_connection_state_callback(callback)
 
     async def connect_side_effect():
-        mock_transport.add_connection_status_callback.assert_called_once_with(callback)
-        registered_callback = mock_transport.add_connection_status_callback.call_args[
+        mock_transport.add_connection_state_callback.assert_called_once_with(callback)
+        registered_callback = mock_transport.add_connection_state_callback.call_args[0][
             0
-        ][0]
+        ]
         registered_callback()
 
     mock_transport.connect.side_effect = connect_side_effect
@@ -388,13 +388,13 @@ async def test_connection_status_callback_called_on_read_disconnect(
     mock_connection, mock_transport
 ):
     callback = MagicMock()
-    mock_connection.add_connection_status_callback(callback)
+    mock_connection.add_connection_state_callback(callback)
 
     async def read_frame_side_effect():
         mock_transport.add_connection_state_callback.assert_called_once_with(callback)
-        registered_callback = mock_transport.add_connection_status_callback.call_args[
+        registered_callback = mock_transport.add_connection_state_callback.call_args[0][
             0
-        ][0]
+        ]
         registered_callback()
         return None
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, PropertyMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -358,49 +358,3 @@ async def test_wait_stopped_blocks_until_connection_closes(
     await mock_connection.close()
 
     await asyncio.wait_for(waiter, timeout=1.0)
-
-
-@pytest.mark.asyncio
-async def test_connection_status_callback_called_on_connect(
-    mock_connection, mock_transport
-):
-    callback = MagicMock()
-    mock_connection.add_connection_state_callback(callback)
-
-    async def connect_side_effect():
-        mock_transport.add_connection_state_callback.assert_called_once_with(callback)
-        registered_callback = mock_transport.add_connection_state_callback.call_args[0][
-            0
-        ]
-        registered_callback()
-
-    mock_transport.connect.side_effect = connect_side_effect
-    type(mock_transport).connected = PropertyMock(side_effect=[False, False, True])
-
-    result = await mock_connection.connect()
-
-    assert result is True
-    callback.assert_called_once_with()
-
-
-@pytest.mark.asyncio
-async def test_connection_status_callback_called_on_read_disconnect(
-    mock_connection, mock_transport
-):
-    callback = MagicMock()
-    mock_connection.add_connection_state_callback(callback)
-
-    async def read_frame_side_effect():
-        mock_transport.add_connection_state_callback.assert_called_once_with(callback)
-        registered_callback = mock_transport.add_connection_state_callback.call_args[0][
-            0
-        ]
-        registered_callback()
-        return None
-
-    mock_transport.read_frame = AsyncMock(side_effect=read_frame_side_effect)
-
-    result = await mock_connection.read_frame()
-
-    assert result is None
-    callback.assert_called_once_with()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
 import pytest
 
@@ -358,3 +358,35 @@ async def test_wait_stopped_blocks_until_connection_closes(
     await mock_connection.close()
 
     await asyncio.wait_for(waiter, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_connection_status_callback_called_on_connect(
+    mock_connection, mock_transport
+):
+    callback = MagicMock()
+    mock_connection.set_connection_status_callback(callback)
+
+    type(mock_transport).connected = PropertyMock(side_effect=[False, False, True])
+
+    result = await mock_connection.connect()
+
+    assert result is True
+    callback.assert_called_once_with(True)
+
+
+@pytest.mark.asyncio
+async def test_connection_status_callback_called_on_read_disconnect(
+    mock_connection, mock_transport
+):
+    callback = MagicMock()
+    mock_connection.set_connection_status_callback(callback)
+
+    mock_connection._last_connected_state = True
+    type(mock_transport).connected = PropertyMock(return_value=False)
+    mock_transport.read_frame = AsyncMock(return_value=None)
+
+    result = await mock_connection.read_frame()
+
+    assert result is None
+    callback.assert_called_once_with(False)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -365,14 +365,22 @@ async def test_connection_status_callback_called_on_connect(
     mock_connection, mock_transport
 ):
     callback = MagicMock()
-    mock_connection.set_connection_status_callback(callback)
+    mock_connection.add_connection_status_callback(callback)
 
+    async def connect_side_effect():
+        mock_transport.add_connection_status_callback.assert_called_once_with(callback)
+        registered_callback = mock_transport.add_connection_status_callback.call_args[
+            0
+        ][0]
+        registered_callback()
+
+    mock_transport.connect.side_effect = connect_side_effect
     type(mock_transport).connected = PropertyMock(side_effect=[False, False, True])
 
     result = await mock_connection.connect()
 
     assert result is True
-    callback.assert_called_once_with(True)
+    callback.assert_called_once_with()
 
 
 @pytest.mark.asyncio
@@ -380,13 +388,19 @@ async def test_connection_status_callback_called_on_read_disconnect(
     mock_connection, mock_transport
 ):
     callback = MagicMock()
-    mock_connection.set_connection_status_callback(callback)
+    mock_connection.add_connection_status_callback(callback)
 
-    mock_connection._last_connected_state = True
-    type(mock_transport).connected = PropertyMock(return_value=False)
-    mock_transport.read_frame = AsyncMock(return_value=None)
+    async def read_frame_side_effect():
+        mock_transport.add_connection_state_callback.assert_called_once_with(callback)
+        registered_callback = mock_transport.add_connection_status_callback.call_args[
+            0
+        ][0]
+        registered_callback()
+        return None
+
+    mock_transport.read_frame = AsyncMock(side_effect=read_frame_side_effect)
 
     result = await mock_connection.read_frame()
 
     assert result is None
-    callback.assert_called_once_with(False)
+    callback.assert_called_once_with()

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -21,6 +21,7 @@ def mock_connection():
     conn.ensure_connected = AsyncMock(return_value=True)
     conn.wait_reconnected = AsyncMock(return_value=True)
     conn.wait_stopped = AsyncMock(return_value=None)
+    conn.set_connection_status_callback = MagicMock()
     return conn
 
 
@@ -335,3 +336,11 @@ async def test_connect_raises_in_strict_mode_for_connect_exceptions(
 
     with pytest.raises(exc_type, match="boom"):
         await satel.connect(raise_exceptions=True)
+
+
+def test_register_callbacks_forwards_connection_status_callback(satel, mock_connection):
+    callback = MagicMock()
+
+    satel.register_callbacks(connection_status_changed_callback=callback)
+
+    mock_connection.set_connection_status_callback.assert_called_once_with(callback)

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -338,9 +338,19 @@ async def test_connect_raises_in_strict_mode_for_connect_exceptions(
         await satel.connect(raise_exceptions=True)
 
 
-def test_register_callbacks_forwards_connection_status_callback(satel, mock_connection):
+def test_add_connection_status_callback_forwards_to_transport(satel, mock_connection):
     callback = MagicMock()
 
-    satel.register_callbacks(connection_status_changed_callback=callback)
+    satel.add_connection_status_callback(callback)
 
-    mock_connection.set_connection_status_callback.assert_called_once_with(callback)
+    mock_connection.add_connection_state_callback.assert_called_once_with(callback)
+
+
+def test_remove_connection_status_callback_forwards_to_transport(
+    satel, mock_connection
+):
+    callback = MagicMock()
+
+    satel.remove_connection_status_callback(callback)
+
+    mock_connection.remove_connection_state_callback.assert_called_once_with(callback)

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -21,7 +21,7 @@ def mock_connection():
     conn.ensure_connected = AsyncMock(return_value=True)
     conn.wait_reconnected = AsyncMock(return_value=True)
     conn.wait_stopped = AsyncMock(return_value=None)
-    conn.set_connection_status_callback = MagicMock()
+    conn.add_connection_state_callback = MagicMock()
     return conn
 
 
@@ -344,13 +344,3 @@ def test_add_connection_status_callback_forwards_to_transport(satel, mock_connec
     satel.add_connection_status_callback(callback)
 
     mock_connection.add_connection_state_callback.assert_called_once_with(callback)
-
-
-def test_remove_connection_status_callback_forwards_to_transport(
-    satel, mock_connection
-):
-    callback = MagicMock()
-
-    satel.remove_connection_status_callback(callback)
-
-    mock_connection.remove_connection_state_callback.assert_called_once_with(callback)

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -106,7 +106,7 @@ async def test_connection_state_callback_called_on_connect(monkeypatch):
     callback = MagicMock()
 
     transport = SatelBaseTransport("localhost", 1234)
-    transport.set_connection_state_callback(callback)
+    transport.add_connection_state_callback(callback)
 
     await transport.connect()
 
@@ -129,45 +129,6 @@ async def test_multiple_connection_state_callbacks(monkeypatch):
     await transport.connect()
 
     callback1.assert_called_once_with()
-    callback2.assert_called_once_with()
-
-
-@pytest.mark.asyncio
-async def test_remove_connection_state_callback(monkeypatch):
-    reader, writer = AsyncMock(), AsyncMock()
-    monkeypatch.setattr(
-        asyncio, "open_connection", AsyncMock(return_value=(reader, writer))
-    )
-    callback1 = MagicMock()
-    callback2 = MagicMock()
-
-    transport = SatelBaseTransport("localhost", 1234)
-    transport.add_connection_state_callback(callback1)
-    transport.add_connection_state_callback(callback2)
-    transport.remove_connection_state_callback(callback1)
-
-    await transport.connect()
-
-    callback1.assert_not_called()
-    callback2.assert_called_once_with()
-
-
-@pytest.mark.asyncio
-async def test_set_connection_state_callback_overwrites(monkeypatch):
-    reader, writer = AsyncMock(), AsyncMock()
-    monkeypatch.setattr(
-        asyncio, "open_connection", AsyncMock(return_value=(reader, writer))
-    )
-    callback1 = MagicMock()
-    callback2 = MagicMock()
-
-    transport = SatelBaseTransport("localhost", 1234)
-    transport.add_connection_state_callback(callback1)
-    transport.set_connection_state_callback(callback2)  # Should overwrite
-
-    await transport.connect()
-
-    callback1.assert_not_called()
     callback2.assert_called_once_with()
 
 
@@ -272,7 +233,7 @@ async def test_close_already_stopped(mock_transport):
 
 async def test_connection_state_callback_called_on_close(mock_transport):
     callback = MagicMock()
-    mock_transport.set_connection_state_callback(callback)
+    mock_transport.add_connection_state_callback(callback)
     mock_transport._last_connected_state = True
     mock_transport._writer.is_closing = MagicMock(return_value=False)
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -98,6 +98,7 @@ async def test_read_initial_data_not_connected(caplog):
     assert "Cannot read initial data, not connected." in caplog.text
 
 
+@pytest.mark.asyncio
 async def test_connection_state_callback_called_on_connect(monkeypatch):
     reader, writer = AsyncMock(), AsyncMock()
     monkeypatch.setattr(
@@ -130,19 +131,6 @@ async def test_multiple_connection_state_callbacks(monkeypatch):
 
     callback1.assert_called_once_with()
     callback2.assert_called_once_with()
-
-
-@pytest.mark.asyncio
-async def test_check_connection_busy_message(mock_transport, caplog):
-    mock_transport._reader.read.return_value = (
-        b"\x10Busy!\r\n\xd8\xa5\xa5\xa5\xa5\xa5\xa5\xa5"
-    )
-
-    with caplog.at_level(logging.WARNING):
-        result = await mock_transport.read_initial_data()
-
-    assert result is None
-    assert "Cannot read initial data, not connected." in caplog.text
 
 
 @pytest.mark.asyncio
@@ -226,11 +214,6 @@ async def test_close_success(mock_transport):
 
 
 @pytest.mark.asyncio
-async def test_close_already_stopped(mock_transport):
-    mock_transport.stopped = True
-    await mock_transport.close()  # should not raise or call anything
-
-
 async def test_connection_state_callback_called_on_close(mock_transport):
     callback = AsyncMock()
     mock_transport.add_connection_state_callback(callback)
@@ -293,3 +276,19 @@ async def test_write_encrypted(encryption_handler, mock_encrypted_transport):
     mock_encrypted_transport._writer.write.assert_called_once_with(
         bytes([len(encrypted_data)]) + encrypted_data
     )
+
+
+@pytest.mark.asyncio
+async def test_connection_state_sync_callback_called_on_connect(monkeypatch):
+    reader, writer = AsyncMock(), AsyncMock()
+    monkeypatch.setattr(
+        asyncio, "open_connection", AsyncMock(return_value=(reader, writer))
+    )
+    callback = MagicMock()
+
+    transport = SatelBaseTransport("localhost", 1234)
+    transport.add_connection_state_callback(callback)
+
+    await transport.connect()
+
+    callback.assert_called_once_with()

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -103,7 +103,7 @@ async def test_connection_state_callback_called_on_connect(monkeypatch):
     monkeypatch.setattr(
         asyncio, "open_connection", AsyncMock(return_value=(reader, writer))
     )
-    callback = MagicMock()
+    callback = AsyncMock()
 
     transport = SatelBaseTransport("localhost", 1234)
     transport.add_connection_state_callback(callback)
@@ -119,8 +119,8 @@ async def test_multiple_connection_state_callbacks(monkeypatch):
     monkeypatch.setattr(
         asyncio, "open_connection", AsyncMock(return_value=(reader, writer))
     )
-    callback1 = MagicMock()
-    callback2 = MagicMock()
+    callback1 = AsyncMock()
+    callback2 = AsyncMock()
 
     transport = SatelBaseTransport("localhost", 1234)
     transport.add_connection_state_callback(callback1)
@@ -232,9 +232,8 @@ async def test_close_already_stopped(mock_transport):
 
 
 async def test_connection_state_callback_called_on_close(mock_transport):
-    callback = MagicMock()
+    callback = AsyncMock()
     mock_transport.add_connection_state_callback(callback)
-    mock_transport._last_connected_state = True
     mock_transport._writer.is_closing = MagicMock(return_value=False)
 
     await mock_transport.close()

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -134,6 +134,40 @@ async def test_multiple_connection_state_callbacks(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_connection_state_callback_not_called_on_failed_connect(monkeypatch):
+    monkeypatch.setattr(
+        asyncio, "open_connection", AsyncMock(side_effect=OSError("boom"))
+    )
+    callback = AsyncMock()
+
+    transport = SatelBaseTransport("localhost", 1234)
+    transport.add_connection_state_callback(callback)
+
+    with pytest.raises(SatelConnectFailedError):
+        await transport.connect()
+
+    callback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_connection_state_callback_exception_does_not_fail_connect(monkeypatch):
+    reader, writer = AsyncMock(), AsyncMock()
+    monkeypatch.setattr(
+        asyncio, "open_connection", AsyncMock(return_value=(reader, writer))
+    )
+
+    def bad_callback():
+        raise ValueError("boom")
+
+    transport = SatelBaseTransport("localhost", 1234)
+    transport.add_connection_state_callback(bad_callback)
+
+    await transport.connect()
+
+    assert transport.connected
+
+
+@pytest.mark.asyncio
 async def test_read_frame_success(mock_transport):
     from satel_integra.const import FRAME_END
 
@@ -218,6 +252,7 @@ async def test_connection_state_callback_called_on_close(mock_transport):
     callback = AsyncMock()
     mock_transport.add_connection_state_callback(callback)
     mock_transport._writer.is_closing = MagicMock(return_value=False)
+    mock_transport._connection_event.set()
 
     await mock_transport.close()
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -98,6 +98,92 @@ async def test_read_initial_data_not_connected(caplog):
     assert "Cannot read initial data, not connected." in caplog.text
 
 
+async def test_connection_state_callback_called_on_connect(monkeypatch):
+    reader, writer = AsyncMock(), AsyncMock()
+    monkeypatch.setattr(
+        asyncio, "open_connection", AsyncMock(return_value=(reader, writer))
+    )
+    callback = MagicMock()
+
+    transport = SatelBaseTransport("localhost", 1234)
+    transport.set_connection_state_callback(callback)
+
+    await transport.connect()
+
+    callback.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_multiple_connection_state_callbacks(monkeypatch):
+    reader, writer = AsyncMock(), AsyncMock()
+    monkeypatch.setattr(
+        asyncio, "open_connection", AsyncMock(return_value=(reader, writer))
+    )
+    callback1 = MagicMock()
+    callback2 = MagicMock()
+
+    transport = SatelBaseTransport("localhost", 1234)
+    transport.add_connection_state_callback(callback1)
+    transport.add_connection_state_callback(callback2)
+
+    await transport.connect()
+
+    callback1.assert_called_once_with()
+    callback2.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_remove_connection_state_callback(monkeypatch):
+    reader, writer = AsyncMock(), AsyncMock()
+    monkeypatch.setattr(
+        asyncio, "open_connection", AsyncMock(return_value=(reader, writer))
+    )
+    callback1 = MagicMock()
+    callback2 = MagicMock()
+
+    transport = SatelBaseTransport("localhost", 1234)
+    transport.add_connection_state_callback(callback1)
+    transport.add_connection_state_callback(callback2)
+    transport.remove_connection_state_callback(callback1)
+
+    await transport.connect()
+
+    callback1.assert_not_called()
+    callback2.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_set_connection_state_callback_overwrites(monkeypatch):
+    reader, writer = AsyncMock(), AsyncMock()
+    monkeypatch.setattr(
+        asyncio, "open_connection", AsyncMock(return_value=(reader, writer))
+    )
+    callback1 = MagicMock()
+    callback2 = MagicMock()
+
+    transport = SatelBaseTransport("localhost", 1234)
+    transport.add_connection_state_callback(callback1)
+    transport.set_connection_state_callback(callback2)  # Should overwrite
+
+    await transport.connect()
+
+    callback1.assert_not_called()
+    callback2.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_check_connection_busy_message(mock_transport, caplog):
+    mock_transport._reader.read.return_value = (
+        b"\x10Busy!\r\n\xd8\xa5\xa5\xa5\xa5\xa5\xa5\xa5"
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = await mock_transport.read_initial_data()
+
+    assert result is None
+    assert "Cannot read initial data, not connected." in caplog.text
+
+
 @pytest.mark.asyncio
 async def test_read_frame_success(mock_transport):
     from satel_integra.const import FRAME_END
@@ -182,6 +268,17 @@ async def test_close_success(mock_transport):
 async def test_close_already_stopped(mock_transport):
     mock_transport.stopped = True
     await mock_transport.close()  # should not raise or call anything
+
+
+async def test_connection_state_callback_called_on_close(mock_transport):
+    callback = MagicMock()
+    mock_transport.set_connection_state_callback(callback)
+    mock_transport._last_connected_state = True
+    mock_transport._writer.is_closing = MagicMock(return_value=False)
+
+    await mock_transport.close()
+
+    callback.assert_called_once_with()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Adds the ability to register connectivity changes callbacks. These are useful to know when connection gets dropped and mark devices as unavailable in Home Assistant for example