### PR TITLE
Add keepalive disconnection on send failure

### DIFF
--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -207,6 +207,11 @@ class SatelConnection:
         async with self._connection_lock:
             await self._close_locked()
 
+    async def disconnect(self) -> None:
+        """Drop the current transport without terminally stopping the client."""
+        async with self._connection_lock:
+            await self._close_locked(stop=False)
+
     async def wait_reconnected(self) -> None:
         """Wait for connection to be re-established after being lost.
 

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -266,6 +266,9 @@ class AsyncSatel:
             await asyncio.sleep(sleep_duration)
             if self.stopped:
                 return
+            if not self.connected:
+                next_keepalive += interval
+                continue
 
             started = loop.time()
             data = SatelWriteMessage(

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -273,7 +273,10 @@ class AsyncSatel:
             )
 
             try:
-                await self._send_data(data)
+                result = await self._send_data_and_wait(data)
+                if result is None and self.connected:
+                    _LOGGER.warning("Keepalive timed out, marking connection as lost")
+                    await self._connection.disconnect()
             except asyncio.CancelledError:
                 raise
             except Exception:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -210,6 +210,18 @@ async def test_ensure_connected_raises_when_stopped(mock_connection):
 
 
 @pytest.mark.asyncio
+async def test_disconnect_closes_transport_without_stopping_client(
+    mock_connection, mock_transport
+):
+    mock_transport.connected = True
+
+    await mock_connection.disconnect()
+
+    assert mock_connection.stopped is False
+    mock_transport.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_check_connection_read_exception(mock_connection, mock_transport):
     mock_transport.connected = True
     mock_transport.read_initial_data.side_effect = Exception("boom")

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -269,13 +269,13 @@ async def test_start_returns_early_when_initial_connection_fails(satel, mock_que
 @pytest.mark.asyncio
 async def test_keepalive_loop_stops_when_connection_closes(satel, mock_connection):
     satel._keepalive_timeout = 0.01
-    satel._send_data = AsyncMock(
+    satel._send_data_and_wait = AsyncMock(
         side_effect=lambda *args, **kwargs: setattr(mock_connection, "stopped", True)
     )
 
     await satel._keepalive_loop()
 
-    satel._send_data.assert_called_once()
+    satel._send_data_and_wait.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -279,6 +279,17 @@ async def test_keepalive_loop_stops_when_connection_closes(satel, mock_connectio
 
 
 @pytest.mark.asyncio
+async def test_keepalive_timeout_marks_connection_disconnected(satel, mock_connection):
+    satel._keepalive_timeout = 0.01
+    satel._send_data_and_wait = AsyncMock(side_effect=[None, asyncio.CancelledError()])
+
+    with pytest.raises(asyncio.CancelledError):
+        await satel._keepalive_loop()
+
+    mock_connection.disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_reading_loop_processes_message(satel, mock_connection):
     msg = MagicMock()
     msg.cmd = 1

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -290,6 +290,41 @@ async def test_keepalive_timeout_marks_connection_disconnected(satel, mock_conne
 
 
 @pytest.mark.asyncio
+async def test_keepalive_loop_waits_full_interval_while_disconnected(
+    satel, mock_connection, monkeypatch
+):
+    class FakeLoop:
+        def __init__(self):
+            self.now = 0.0
+
+        def time(self):
+            return self.now
+
+    fake_loop = FakeLoop()
+    satel._keepalive_timeout = 5
+    mock_connection.connected = False
+    sleep_calls = []
+
+    async def fake_sleep(duration):
+        sleep_calls.append(duration)
+        fake_loop.now += duration
+        if len(sleep_calls) == 2:
+            mock_connection.connected = True
+
+    monkeypatch.setattr(
+        "satel_integra.satel_integra.asyncio.get_running_loop", lambda: fake_loop
+    )
+    monkeypatch.setattr("satel_integra.satel_integra.asyncio.sleep", fake_sleep)
+    satel._send_data_and_wait = AsyncMock(side_effect=asyncio.CancelledError())
+
+    with pytest.raises(asyncio.CancelledError):
+        await satel._keepalive_loop()
+
+    assert sleep_calls == [5, 5]
+    satel._send_data_and_wait.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_reading_loop_processes_message(satel, mock_connection):
     msg = MagicMock()
     msg.cmd = 1


### PR DESCRIPTION
Adds the ability for the keep alive loop to disconnect the existing connection when the keep alive message is not returned.
If the message is not returned, there is likely a connection issue going on. We now disconnect from the panel so we can go through the reconnection loop. Additionally, we don't queue and send keep alive messages anymore when we're not connected.