### PR TITLE
Adjust keepalive loop

### DIFF
--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -47,6 +47,7 @@ class SatelConnection:
             asyncio.Event()
         )  # Signals when connection is re-established
         self._had_connection = False
+        self._last_activity: float | None = None
 
     @property
     def connected(self) -> bool:
@@ -58,6 +59,11 @@ class SatelConnection:
         """Return True if the connection is stopped."""
         return self._stopped
 
+    @property
+    def last_activity(self) -> float | None:
+        """Return the loop timestamp of the last observed connection traffic."""
+        return self._last_activity
+
     def _assert_not_stopped(self) -> None:
         """Raise if the connection is in a terminal stopped state."""
         if self.stopped:
@@ -66,6 +72,10 @@ class SatelConnection:
     def add_connection_state_callback(self, callback: ConnectionStateCallback) -> None:
         """Register callback called when connection status changes."""
         self._transport.add_connection_state_callback(callback)
+
+    def _now(self) -> float:
+        """Return the running loop's monotonic time for interval tracking."""
+        return asyncio.get_running_loop().time()
 
     async def _connect(self, verify_connection: bool = True) -> None:
         """Establish TCP connection. Must be called with _connection_lock held."""
@@ -123,6 +133,7 @@ class SatelConnection:
             )
 
         _LOGGER.debug("Connected to Satel Integra.")
+        self._last_activity = self._now()
         # If we've had a successful connection before, this is a
         # reconnection — signal any waiters. Otherwise mark that we've
         # now had a connection so future connects can be treated as
@@ -147,11 +158,17 @@ class SatelConnection:
 
     async def read_frame(self) -> bytes | None:
         """Read a raw frame from the panel."""
-        return await self._transport.read_frame()
+        frame = await self._transport.read_frame()
+        if frame:
+            self._last_activity = self._now()
+        return frame
 
     async def send_frame(self, frame: bytes) -> bool:
         """Send a raw frame to the panel."""
-        return await self._transport.send_frame(frame)
+        sent = await self._transport.send_frame(frame)
+        if sent:
+            self._last_activity = self._now()
+        return sent
 
     async def ensure_connected(self) -> None:
         """Reconnect automatically until connected or terminally stopped."""
@@ -189,6 +206,7 @@ class SatelConnection:
 
         _LOGGER.debug("Closing connection...")
         await self._transport.close()
+        self._last_activity = None
 
         if stop:
             self._stopped = True
@@ -249,9 +267,9 @@ class SatelConnection:
         try:
             probe = SatelWriteMessage(SatelWriteCommand.RTC_AND_STATUS)
 
-            await self._transport.send_frame(probe.encode_frame())
+            await self.send_frame(probe.encode_frame())
             raw_response = await asyncio.wait_for(
-                self._transport.read_frame(), timeout=MESSAGE_RESPONSE_TIMEOUT
+                self.read_frame(), timeout=MESSAGE_RESPONSE_TIMEOUT
             )
         except asyncio.TimeoutError as exc:
             _LOGGER.debug(

--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -47,7 +47,7 @@ class SatelConnection:
             asyncio.Event()
         )  # Signals when connection is re-established
         self._had_connection = False
-        self._last_activity: float | None = None
+        self._last_outbound_activity: float | None = None
 
     @property
     def connected(self) -> bool:
@@ -60,9 +60,9 @@ class SatelConnection:
         return self._stopped
 
     @property
-    def last_activity(self) -> float | None:
-        """Return the loop timestamp of the last observed connection traffic."""
-        return self._last_activity
+    def last_outbound_activity(self) -> float | None:
+        """Return the loop timestamp of the last outbound panel command."""
+        return self._last_outbound_activity
 
     def _assert_not_stopped(self) -> None:
         """Raise if the connection is in a terminal stopped state."""
@@ -133,7 +133,6 @@ class SatelConnection:
             )
 
         _LOGGER.debug("Connected to Satel Integra.")
-        self._last_activity = self._now()
         # If we've had a successful connection before, this is a
         # reconnection — signal any waiters. Otherwise mark that we've
         # now had a connection so future connects can be treated as
@@ -158,16 +157,13 @@ class SatelConnection:
 
     async def read_frame(self) -> bytes | None:
         """Read a raw frame from the panel."""
-        frame = await self._transport.read_frame()
-        if frame:
-            self._last_activity = self._now()
-        return frame
+        return await self._transport.read_frame()
 
     async def send_frame(self, frame: bytes) -> bool:
         """Send a raw frame to the panel."""
         sent = await self._transport.send_frame(frame)
         if sent:
-            self._last_activity = self._now()
+            self._last_outbound_activity = self._now()
         return sent
 
     async def ensure_connected(self) -> None:
@@ -206,7 +202,7 @@ class SatelConnection:
 
         _LOGGER.debug("Closing connection...")
         await self._transport.close()
-        self._last_activity = None
+        self._last_outbound_activity = None
 
         if stop:
             self._stopped = True

--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -48,6 +48,7 @@ class SatelConnection:
         )  # Signals when connection is re-established
         self._had_connection = False
         self._last_outbound_activity: float | None = None
+        self._generation = 0
 
     @property
     def connected(self) -> bool:
@@ -63,6 +64,11 @@ class SatelConnection:
     def last_outbound_activity(self) -> float | None:
         """Return the loop timestamp of the last outbound panel command."""
         return self._last_outbound_activity
+
+    @property
+    def generation(self) -> int:
+        """Return the current successful connection generation."""
+        return self._generation
 
     def _assert_not_stopped(self) -> None:
         """Raise if the connection is in a terminal stopped state."""
@@ -133,6 +139,7 @@ class SatelConnection:
             )
 
         _LOGGER.debug("Connected to Satel Integra.")
+        self._generation += 1
         # If we've had a successful connection before, this is a
         # reconnection — signal any waiters. Otherwise mark that we've
         # now had a connection so future connects can be treated as

--- a/satel_integra/const.py
+++ b/satel_integra/const.py
@@ -9,5 +9,6 @@ FRAME_SPECIAL_BYTES = bytes([0xFE])
 FRAME_SPECIAL_BYTES_REPLACEMENT = bytes([0xFE, 0xF0])
 
 MESSAGE_RESPONSE_TIMEOUT = 5
+KEEPALIVE_INTERVAL = 15
 
 ConnectionStateCallback = Callable[[], None | Awaitable[None]]

--- a/satel_integra/queue.py
+++ b/satel_integra/queue.py
@@ -145,8 +145,10 @@ class SatelMessageQueue:
                 queued.processed_future, timeout=MESSAGE_RESPONSE_TIMEOUT
             )
         except asyncio.TimeoutError:
-            _LOGGER.error(
-                "No response received from panel within %ss", MESSAGE_RESPONSE_TIMEOUT
+            _LOGGER.debug(
+                "No response received from panel within %ss for message: %s",
+                MESSAGE_RESPONSE_TIMEOUT,
+                queued.message,
             )
             if not queued.processed_future.done():
                 queued.processed_future.cancel()

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -265,17 +265,19 @@ class AsyncSatel:
         )
 
         while True:
+            now = loop.time()
             last_outbound_activity = self._connection.last_outbound_activity
+
             if last_outbound_activity is None:
-                last_outbound_activity = loop.time()
+                last_outbound_activity = now
 
             # Sleep until next possible interval
             deadline = last_outbound_activity + KEEPALIVE_INTERVAL
-            sleep_duration = max(0, deadline - loop.time())
+            sleep_duration = max(0, deadline - now)
             await asyncio.sleep(sleep_duration)
 
-            woke_at = loop.time()
-            if (wakeup_lag := woke_at - deadline) > 1:
+            now = loop.time()
+            if (wakeup_lag := now - deadline) > 1:
                 _LOGGER.debug(
                     "Keepalive woke up %.3fs after the idle deadline",
                     wakeup_lag,
@@ -291,7 +293,7 @@ class AsyncSatel:
                 last_outbound_activity = observed
 
             # Check if we exceeded the interval after sleeping
-            idle_for = loop.time() - last_outbound_activity
+            idle_for = now - last_outbound_activity
             if idle_for < KEEPALIVE_INTERVAL:
                 _LOGGER.debug(
                     "Keepalive skipped because outbound activity was seen %.3fs ago",

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -305,13 +305,28 @@ class AsyncSatel:
             _LOGGER.debug(
                 "Keepalive sending after %.3fs of outbound inactivity", idle_for
             )
+            connection_generation = self._connection.generation
 
             try:
                 result = await self._send_data_and_wait(data)
                 if result is None:
-                    _LOGGER.debug(
-                        "Keepalive timed out; leaving connection state unchanged"
-                    )
+                    # Check if connection is still the same and mark as lost if so
+                    # This can happen when network is down, but the connection didn't really close
+                    if (
+                        self.connected
+                        and self._connection.generation == connection_generation
+                    ):
+                        _LOGGER.debug(
+                            "Keepalive timed out on current connection; "
+                            "marking connection as lost"
+                        )
+                        await self._connection.disconnect()
+                    else:
+                        _LOGGER.debug(
+                            "Ignoring stale keepalive timeout from connection "
+                            "generation %s",
+                            connection_generation,
+                        )
             except asyncio.CancelledError:
                 raise
             except Exception:

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -10,7 +10,7 @@ from warnings import warn
 
 from satel_integra.commands import SatelReadCommand, SatelWriteCommand
 from satel_integra.connection import SatelConnection
-from satel_integra.const import ConnectionStateCallback
+from satel_integra.const import KEEPALIVE_INTERVAL, ConnectionStateCallback
 from satel_integra.exceptions import (
     SatelConnectFailedError,
     SatelConnectionInitializationError,
@@ -78,7 +78,6 @@ class AsyncSatel:
         self._connection = SatelConnection(host, port, integration_key=integration_key)
         self._queue = SatelMessageQueue(self._send_encoded_frame)
         self._running_tasks: set[asyncio.Task[object]] = set()
-        self._keepalive_timeout = 20
 
         self._monitored_zones: list[int] = monitored_zones
         self.violated_zones: list[int] = []
@@ -258,22 +257,42 @@ class AsyncSatel:
         answer - just to keep connection alive.
         """
         loop = asyncio.get_running_loop()
-        interval = self._keepalive_timeout
-        next_keepalive = loop.time() + interval
+        _LOGGER.debug(
+            "Keepalive loop started with %.1fs idle timeout", KEEPALIVE_INTERVAL
+        )
 
         while True:
-            sleep_duration = max(0, next_keepalive - loop.time())
+            last_activity = self._connection.last_activity
+            if last_activity is None:
+                last_activity = loop.time()
+
+            # Sleep until next possible interval
+            deadline = last_activity + KEEPALIVE_INTERVAL
+            sleep_duration = max(0, deadline - loop.time())
             await asyncio.sleep(sleep_duration)
+
             if self.stopped:
                 return
             if not self.connected:
-                next_keepalive += interval
+                _LOGGER.debug("Keepalive suppressed because the connection is down")
                 continue
 
-            started = loop.time()
+            if (observed := self._connection.last_activity) is not None:
+                last_activity = observed
+
+            # Check if we exceeded the interval after sleeping
+            idle_for = loop.time() - last_activity
+            if idle_for < KEEPALIVE_INTERVAL:
+                _LOGGER.debug(
+                    "Keepalive skipped because activity was seen %.3fs ago",
+                    idle_for,
+                )
+                continue
+
             data = SatelWriteMessage(
                 SatelWriteCommand.READ_DEVICE_NAME, raw_data=bytearray([0x01, 0x01])
             )
+            _LOGGER.debug("Keepalive sending after %.3fs of inactivity", idle_for)
 
             try:
                 result = await self._send_data_and_wait(data)
@@ -284,17 +303,6 @@ class AsyncSatel:
                 raise
             except Exception:
                 _LOGGER.exception("Keepalive send failed")
-
-            lag = started - next_keepalive
-
-            if lag > 5:
-                _LOGGER.debug("Keepalive woke up late by %.3fs", lag)
-
-            next_keepalive += interval
-
-            if loop.time() > next_keepalive + interval:
-                _LOGGER.debug("Keepalive loop fell behind, resynchronizing")
-                next_keepalive = loop.time() + interval
 
     async def _watch_connection_stopped(self):
         """Stop local background work once the connection becomes terminally stopped."""

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -78,6 +78,9 @@ class AsyncSatel:
         self._connection = SatelConnection(host, port, integration_key=integration_key)
         self._queue = SatelMessageQueue(self._send_encoded_frame)
         self._running_tasks: set[asyncio.Task[object]] = set()
+        self._closing = False
+        self._connection_unavailable_logged = False
+        self._connection.add_connection_state_callback(self._connection_state_changed)
 
         self._monitored_zones: list[int] = monitored_zones
         self.violated_zones: list[int] = []
@@ -383,6 +386,21 @@ class AsyncSatel:
         if output_changed_callback:
             self._output_changed_callback = output_changed_callback
 
+    def _connection_state_changed(self) -> None:
+        """Log user-facing connection availability changes once per outage."""
+        if self._closing or self.stopped:
+            return
+
+        if not self.connected:
+            if not self._connection_unavailable_logged:
+                _LOGGER.info("Connection to Satel Integra panel lost")
+                self._connection_unavailable_logged = True
+            return
+
+        if self._connection_unavailable_logged:
+            _LOGGER.info("Connection to Satel Integra panel restored")
+            self._connection_unavailable_logged = False
+
     def add_connection_status_callback(self, callback: ConnectionStateCallback) -> None:
         """Add a callback to be called when connection status changes."""
         self._connection.add_connection_state_callback(callback)
@@ -575,6 +593,7 @@ class AsyncSatel:
 
     async def close(self):
         """Stop background tasks and close connection."""
+        self._closing = True
         await self._connection.close()
 
         await self._cancel_running_tasks()

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -265,12 +265,12 @@ class AsyncSatel:
         )
 
         while True:
-            last_activity = self._connection.last_activity
-            if last_activity is None:
-                last_activity = loop.time()
+            last_outbound_activity = self._connection.last_outbound_activity
+            if last_outbound_activity is None:
+                last_outbound_activity = loop.time()
 
             # Sleep until next possible interval
-            deadline = last_activity + KEEPALIVE_INTERVAL
+            deadline = last_outbound_activity + KEEPALIVE_INTERVAL
             sleep_duration = max(0, deadline - loop.time())
             await asyncio.sleep(sleep_duration)
 
@@ -287,14 +287,14 @@ class AsyncSatel:
                 _LOGGER.debug("Keepalive suppressed because the connection is down")
                 continue
 
-            if (observed := self._connection.last_activity) is not None:
-                last_activity = observed
+            if (observed := self._connection.last_outbound_activity) is not None:
+                last_outbound_activity = observed
 
             # Check if we exceeded the interval after sleeping
-            idle_for = loop.time() - last_activity
+            idle_for = loop.time() - last_outbound_activity
             if idle_for < KEEPALIVE_INTERVAL:
                 _LOGGER.debug(
-                    "Keepalive skipped because activity was seen %.3fs ago",
+                    "Keepalive skipped because outbound activity was seen %.3fs ago",
                     idle_for,
                 )
                 continue
@@ -302,7 +302,9 @@ class AsyncSatel:
             data = SatelWriteMessage(
                 SatelWriteCommand.READ_DEVICE_NAME, raw_data=bytearray([0x01, 0x01])
             )
-            _LOGGER.debug("Keepalive sending after %.3fs of inactivity", idle_for)
+            _LOGGER.debug(
+                "Keepalive sending after %.3fs of outbound inactivity", idle_for
+            )
 
             try:
                 result = await self._send_data_and_wait(data)

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -271,6 +271,13 @@ class AsyncSatel:
             sleep_duration = max(0, deadline - loop.time())
             await asyncio.sleep(sleep_duration)
 
+            woke_at = loop.time()
+            if (wakeup_lag := woke_at - deadline) > 1:
+                _LOGGER.debug(
+                    "Keepalive woke up %.3fs after the idle deadline",
+                    wakeup_lag,
+                )
+
             if self.stopped:
                 return
             if not self.connected:
@@ -296,9 +303,10 @@ class AsyncSatel:
 
             try:
                 result = await self._send_data_and_wait(data)
-                if result is None and self.connected:
-                    _LOGGER.warning("Keepalive timed out, marking connection as lost")
-                    await self._connection.disconnect()
+                if result is None:
+                    _LOGGER.debug(
+                        "Keepalive timed out; leaving connection state unchanged"
+                    )
             except asyncio.CancelledError:
                 raise
             except Exception:

--- a/satel_integra/transport.py
+++ b/satel_integra/transport.py
@@ -108,9 +108,8 @@ class SatelBaseTransport:
                 return frame
             else:
                 _LOGGER.debug("Read failed, no frame end marker found.")
-        except asyncio.IncompleteReadError:
-            # Incomplete read due to connection closing
-            pass
+        except asyncio.IncompleteReadError as exc:
+            _LOGGER.debug("Read failed, connection closed by remote peer: %s", exc)
         except Exception as e:
             _LOGGER.debug("Read failed: %s", e)
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -51,6 +51,7 @@ async def test_connect_success(mock_connection, mock_transport):
     mock_transport.send_frame.assert_awaited_once()
     mock_transport.read_frame.assert_awaited_once()
     mock_transport.close.assert_not_awaited()
+    assert mock_connection.generation == 1
 
 
 @pytest.mark.asyncio
@@ -365,6 +366,7 @@ async def test_reconnection_event_set_on_subsequent_connect(
     await mock_connection.connect()
 
     assert mock_connection._reconnected_event.is_set() is True
+    assert mock_connection.generation == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -214,11 +214,41 @@ async def test_disconnect_closes_transport_without_stopping_client(
     mock_connection, mock_transport
 ):
     mock_transport.connected = True
+    mock_connection._last_activity = 123.0
 
     await mock_connection.disconnect()
 
     assert mock_connection.stopped is False
+    assert mock_connection.last_activity is None
     mock_transport.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_send_frame_updates_last_activity_timestamp(mock_connection, monkeypatch):
+    loop = MagicMock()
+    loop.time.return_value = 42.0
+    monkeypatch.setattr(
+        "satel_integra.connection.asyncio.get_running_loop", lambda: loop
+    )
+
+    result = await mock_connection.send_frame(b"frame")
+
+    assert result is True
+    assert mock_connection.last_activity == 42.0
+
+
+@pytest.mark.asyncio
+async def test_read_frame_updates_last_activity_timestamp(mock_connection, monkeypatch):
+    loop = MagicMock()
+    loop.time.return_value = 84.0
+    monkeypatch.setattr(
+        "satel_integra.connection.asyncio.get_running_loop", lambda: loop
+    )
+
+    frame = await mock_connection.read_frame()
+
+    assert frame == b"probe-response"
+    assert mock_connection.last_activity == 84.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -214,17 +214,19 @@ async def test_disconnect_closes_transport_without_stopping_client(
     mock_connection, mock_transport
 ):
     mock_transport.connected = True
-    mock_connection._last_activity = 123.0
+    mock_connection._last_outbound_activity = 123.0
 
     await mock_connection.disconnect()
 
     assert mock_connection.stopped is False
-    assert mock_connection.last_activity is None
+    assert mock_connection.last_outbound_activity is None
     mock_transport.close.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_send_frame_updates_last_activity_timestamp(mock_connection, monkeypatch):
+async def test_send_frame_updates_last_outbound_activity_timestamp(
+    mock_connection, monkeypatch
+):
     loop = MagicMock()
     loop.time.return_value = 42.0
     monkeypatch.setattr(
@@ -234,21 +236,24 @@ async def test_send_frame_updates_last_activity_timestamp(mock_connection, monke
     result = await mock_connection.send_frame(b"frame")
 
     assert result is True
-    assert mock_connection.last_activity == 42.0
+    assert mock_connection.last_outbound_activity == 42.0
 
 
 @pytest.mark.asyncio
-async def test_read_frame_updates_last_activity_timestamp(mock_connection, monkeypatch):
+async def test_read_frame_does_not_update_last_outbound_activity(
+    mock_connection, monkeypatch
+):
     loop = MagicMock()
     loop.time.return_value = 84.0
     monkeypatch.setattr(
         "satel_integra.connection.asyncio.get_running_loop", lambda: loop
     )
+    mock_connection._last_outbound_activity = 42.0
 
     frame = await mock_connection.read_frame()
 
     assert frame == b"probe-response"
-    assert mock_connection.last_activity == 84.0
+    assert mock_connection.last_outbound_activity == 42.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -314,9 +314,10 @@ async def test_send_and_wait_response_timeout(
     # Use a very short timeout for faster test
     monkeypatch.setattr("satel_integra.queue.MESSAGE_RESPONSE_TIMEOUT", 0.01)
 
-    with caplog.at_level(logging.ERROR):
+    with caplog.at_level(logging.DEBUG):
         await mock_queue._send_and_wait_response(queued)
 
     assert "No response received from panel within" in caplog.text
+    assert "for message:" in caplog.text
     assert queued.processed_future.done()
     assert queued.processed_future.cancelled()

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -319,16 +319,40 @@ async def test_keepalive_loop_stops_when_connection_closes(
 
 
 @pytest.mark.asyncio
-async def test_keepalive_timeout_marks_connection_disconnected(
-    satel, mock_connection, monkeypatch
+async def test_keepalive_timeout_leaves_connection_state_unchanged(
+    satel, mock_connection, monkeypatch, caplog
 ):
     monkeypatch.setattr("satel_integra.satel_integra.KEEPALIVE_INTERVAL", 0.01)
     satel._send_data_and_wait = AsyncMock(side_effect=[None, asyncio.CancelledError()])
 
-    with pytest.raises(asyncio.CancelledError):
-        await satel._keepalive_loop()
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(asyncio.CancelledError):
+            await satel._keepalive_loop()
 
-    mock_connection.disconnect.assert_awaited_once()
+    assert "Keepalive timed out; leaving connection state unchanged" in caplog.text
+    mock_connection.disconnect.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_keepalive_loop_logs_late_wakeup(
+    satel, mock_connection, monkeypatch, caplog, fake_loop
+):
+    sleep_calls = []
+
+    async def fake_sleep(duration):
+        sleep_calls.append(duration)
+        fake_loop.now += duration + 2
+        if len(sleep_calls) > 1:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr("satel_integra.satel_integra.asyncio.sleep", fake_sleep)
+    satel._send_data_and_wait = AsyncMock(return_value=MagicMock())
+
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(asyncio.CancelledError):
+            await satel._keepalive_loop()
+
+    assert "Keepalive woke up 2.000s after the idle deadline" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -501,4 +525,52 @@ def test_add_connection_status_callback_forwards_to_transport(satel, mock_connec
 
     satel.add_connection_status_callback(callback)
 
-    mock_connection.add_connection_state_callback.assert_called_once_with(callback)
+    mock_connection.add_connection_state_callback.assert_any_call(callback)
+
+
+def test_connection_state_changed_logs_lost_once(satel, mock_connection, caplog):
+    mock_connection.connected = False
+    mock_connection.stopped = False
+
+    with caplog.at_level(logging.INFO):
+        satel._connection_state_changed()
+        satel._connection_state_changed()
+
+    assert caplog.text.count("Connection to Satel Integra panel lost") == 1
+
+
+def test_connection_state_changed_logs_restored_once_after_loss(
+    satel, mock_connection, caplog
+):
+    mock_connection.connected = False
+    satel._connection_state_changed()
+
+    mock_connection.connected = True
+    with caplog.at_level(logging.INFO):
+        satel._connection_state_changed()
+        satel._connection_state_changed()
+
+    assert caplog.text.count("Connection to Satel Integra panel restored") == 1
+
+
+def test_connection_state_changed_does_not_log_restored_without_prior_loss(
+    satel, mock_connection, caplog
+):
+    mock_connection.connected = True
+
+    with caplog.at_level(logging.INFO):
+        satel._connection_state_changed()
+
+    assert "Connection to Satel Integra panel restored" not in caplog.text
+
+
+def test_connection_state_changed_does_not_log_during_shutdown(
+    satel, mock_connection, caplog
+):
+    satel._closing = True
+    mock_connection.connected = False
+
+    with caplog.at_level(logging.INFO):
+        satel._connection_state_changed()
+
+    assert "Connection to Satel Integra panel lost" not in caplog.text

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -28,7 +28,7 @@ def mock_connection():
     conn = AsyncMock()
     conn.connected = True
     conn.stopped = False
-    conn.last_activity = None
+    conn.last_outbound_activity = None
     conn.ensure_connected = AsyncMock(return_value=True)
     conn.wait_reconnected = AsyncMock(return_value=True)
     conn.wait_stopped = AsyncMock(return_value=None)
@@ -375,12 +375,12 @@ async def test_keepalive_loop_waits_full_interval_while_disconnected(
 
 
 @pytest.mark.asyncio
-async def test_keepalive_loop_skips_send_when_recent_traffic_seen(
+async def test_keepalive_loop_skips_send_when_recent_outbound_traffic_seen(
     satel, mock_connection, fake_sleep_factory
 ):
     sleep_calls = fake_sleep_factory(
         lambda sleep_count, _duration, loop: (
-            setattr(mock_connection, "last_activity", loop.now)
+            setattr(mock_connection, "last_outbound_activity", loop.now)
             if sleep_count == 1
             else None
         )
@@ -402,14 +402,14 @@ async def test_keepalive_loop_logs_why_send_was_skipped(
         lambda sleep_count, _duration, loop: (
             setattr(mock_connection, "stopped", True)
             if sleep_count == 2
-            else setattr(mock_connection, "last_activity", loop.now)
+            else setattr(mock_connection, "last_outbound_activity", loop.now)
         )
     )
 
     with caplog.at_level(logging.DEBUG):
         await satel._keepalive_loop()
 
-    assert "Keepalive skipped because activity was seen" in caplog.text
+    assert "Keepalive skipped because outbound activity was seen" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -28,6 +28,7 @@ def mock_connection():
     conn = AsyncMock()
     conn.connected = True
     conn.stopped = False
+    conn.generation = 1
     conn.last_outbound_activity = None
     conn.ensure_connected = AsyncMock(return_value=True)
     conn.wait_reconnected = AsyncMock(return_value=True)
@@ -319,7 +320,7 @@ async def test_keepalive_loop_stops_when_connection_closes(
 
 
 @pytest.mark.asyncio
-async def test_keepalive_timeout_leaves_connection_state_unchanged(
+async def test_keepalive_timeout_marks_same_connection_as_lost(
     satel, mock_connection, monkeypatch, caplog
 ):
     monkeypatch.setattr("satel_integra.satel_integra.KEEPALIVE_INTERVAL", 0.01)
@@ -329,7 +330,34 @@ async def test_keepalive_timeout_leaves_connection_state_unchanged(
         with pytest.raises(asyncio.CancelledError):
             await satel._keepalive_loop()
 
-    assert "Keepalive timed out; leaving connection state unchanged" in caplog.text
+    assert "Keepalive timed out on current connection" in caplog.text
+    mock_connection.disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stale_keepalive_timeout_does_not_disconnect_reconnected_session(
+    satel, mock_connection, monkeypatch, caplog
+):
+    monkeypatch.setattr("satel_integra.satel_integra.KEEPALIVE_INTERVAL", 0.01)
+    calls = 0
+
+    async def timeout_after_reconnect(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls > 1:
+            raise asyncio.CancelledError
+        mock_connection.generation = 2
+        return None
+
+    satel._send_data_and_wait = AsyncMock(side_effect=timeout_after_reconnect)
+
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(asyncio.CancelledError):
+            await satel._keepalive_loop()
+
+    assert (
+        "Ignoring stale keepalive timeout from connection generation 1" in caplog.text
+    )
     mock_connection.disconnect.assert_not_awaited()
 
 

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -15,11 +15,20 @@ from satel_integra.messages import SatelZoneTemperatureReadMessage
 from satel_integra.satel_integra import AlarmState, AsyncSatel
 
 
+class FakeLoop:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def time(self) -> float:
+        return self.now
+
+
 @pytest.fixture
 def mock_connection():
     conn = AsyncMock()
     conn.connected = True
     conn.stopped = False
+    conn.last_activity = None
     conn.ensure_connected = AsyncMock(return_value=True)
     conn.wait_reconnected = AsyncMock(return_value=True)
     conn.wait_stopped = AsyncMock(return_value=None)
@@ -52,6 +61,33 @@ def satel(monkeypatch, mock_connection, mock_queue):
     satel._connection = mock_connection
     satel._queue = mock_queue
     return satel
+
+
+@pytest.fixture
+def fake_loop(monkeypatch):
+    loop = FakeLoop()
+    monkeypatch.setattr(
+        "satel_integra.satel_integra.asyncio.get_running_loop", lambda: loop
+    )
+    monkeypatch.setattr("satel_integra.satel_integra.KEEPALIVE_INTERVAL", 5)
+    return loop
+
+
+@pytest.fixture
+def fake_sleep_factory(monkeypatch, fake_loop):
+    def factory(on_sleep=None):
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(duration):
+            sleep_calls.append(duration)
+            fake_loop.now += duration
+            if on_sleep is not None:
+                on_sleep(len(sleep_calls), duration, fake_loop)
+
+        monkeypatch.setattr("satel_integra.satel_integra.asyncio.sleep", fake_sleep)
+        return sleep_calls
+
+    return factory
 
 
 @pytest.mark.asyncio
@@ -267,11 +303,15 @@ async def test_start_returns_early_when_initial_connection_fails(satel, mock_que
 
 
 @pytest.mark.asyncio
-async def test_keepalive_loop_stops_when_connection_closes(satel, mock_connection):
-    satel._keepalive_timeout = 0.01
-    satel._send_data_and_wait = AsyncMock(
-        side_effect=lambda *args, **kwargs: setattr(mock_connection, "stopped", True)
+async def test_keepalive_loop_stops_when_connection_closes(
+    satel, mock_connection, fake_sleep_factory
+):
+    fake_sleep_factory(
+        lambda sleep_count, _duration, _loop: (
+            setattr(mock_connection, "stopped", True) if sleep_count == 2 else None
+        )
     )
+    satel._send_data_and_wait = AsyncMock(return_value=MagicMock())
 
     await satel._keepalive_loop()
 
@@ -279,8 +319,10 @@ async def test_keepalive_loop_stops_when_connection_closes(satel, mock_connectio
 
 
 @pytest.mark.asyncio
-async def test_keepalive_timeout_marks_connection_disconnected(satel, mock_connection):
-    satel._keepalive_timeout = 0.01
+async def test_keepalive_timeout_marks_connection_disconnected(
+    satel, mock_connection, monkeypatch
+):
+    monkeypatch.setattr("satel_integra.satel_integra.KEEPALIVE_INTERVAL", 0.01)
     satel._send_data_and_wait = AsyncMock(side_effect=[None, asyncio.CancelledError()])
 
     with pytest.raises(asyncio.CancelledError):
@@ -291,30 +333,14 @@ async def test_keepalive_timeout_marks_connection_disconnected(satel, mock_conne
 
 @pytest.mark.asyncio
 async def test_keepalive_loop_waits_full_interval_while_disconnected(
-    satel, mock_connection, monkeypatch
+    satel, mock_connection, fake_sleep_factory
 ):
-    class FakeLoop:
-        def __init__(self):
-            self.now = 0.0
-
-        def time(self):
-            return self.now
-
-    fake_loop = FakeLoop()
-    satel._keepalive_timeout = 5
     mock_connection.connected = False
-    sleep_calls = []
-
-    async def fake_sleep(duration):
-        sleep_calls.append(duration)
-        fake_loop.now += duration
-        if len(sleep_calls) == 2:
-            mock_connection.connected = True
-
-    monkeypatch.setattr(
-        "satel_integra.satel_integra.asyncio.get_running_loop", lambda: fake_loop
+    sleep_calls = fake_sleep_factory(
+        lambda sleep_count, _duration, _loop: (
+            setattr(mock_connection, "connected", True) if sleep_count == 2 else None
+        )
     )
-    monkeypatch.setattr("satel_integra.satel_integra.asyncio.sleep", fake_sleep)
     satel._send_data_and_wait = AsyncMock(side_effect=asyncio.CancelledError())
 
     with pytest.raises(asyncio.CancelledError):
@@ -322,6 +348,44 @@ async def test_keepalive_loop_waits_full_interval_while_disconnected(
 
     assert sleep_calls == [5, 5]
     satel._send_data_and_wait.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_keepalive_loop_skips_send_when_recent_traffic_seen(
+    satel, mock_connection, fake_sleep_factory
+):
+    sleep_calls = fake_sleep_factory(
+        lambda sleep_count, _duration, loop: (
+            setattr(mock_connection, "last_activity", loop.now)
+            if sleep_count == 1
+            else None
+        )
+    )
+    satel._send_data_and_wait = AsyncMock(side_effect=asyncio.CancelledError())
+
+    with pytest.raises(asyncio.CancelledError):
+        await satel._keepalive_loop()
+
+    assert sleep_calls == [5, 5]
+    satel._send_data_and_wait.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_keepalive_loop_logs_why_send_was_skipped(
+    satel, mock_connection, caplog, fake_sleep_factory
+):
+    fake_sleep_factory(
+        lambda sleep_count, _duration, loop: (
+            setattr(mock_connection, "stopped", True)
+            if sleep_count == 2
+            else setattr(mock_connection, "last_activity", loop.now)
+        )
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        await satel._keepalive_loop()
+
+    assert "Keepalive skipped because activity was seen" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -206,6 +206,37 @@ async def test_read_frame_timeout(mock_transport):
 
 
 @pytest.mark.asyncio
+async def test_read_frame_incomplete_read_logs_remote_close(mock_transport, caplog):
+    mock_transport._read_from_transport = AsyncMock(
+        side_effect=asyncio.IncompleteReadError(partial=b"", expected=1)
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        result = await mock_transport.read_frame()
+
+    assert result is None
+    assert "Read failed, connection closed by remote peer" in caplog.text
+    assert not mock_transport.connected
+
+
+@pytest.mark.asyncio
+async def test_read_frame_incomplete_read_notifies_connection_state_callback(
+    mock_transport,
+):
+    callback = AsyncMock()
+    mock_transport.add_connection_state_callback(callback)
+    await mock_transport._set_connection_state(True)
+    callback.reset_mock()
+    mock_transport._read_from_transport = AsyncMock(
+        side_effect=asyncio.IncompleteReadError(partial=b"", expected=1)
+    )
+
+    await mock_transport.read_frame()
+
+    callback.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
 async def test_send_frame_success(mock_transport):
     frame = b"abc"
 


### PR DESCRIPTION
Adjusts the keepalive more:
- Adds last activity tracking, instead of sending in fixed intervals, now we send when there's more than x amount of no outbound activity
- Reduced the interval to 15 seconds, this gives 10 seconds of 'late wakeup' time instead of just 5
- Keepalive messages that timed out only disconnect the panel if we are on the same connection generation. This normally means we already surpassed the 25 second mark, and the read loop should have restart the connection. In some cases the time out happens due to other network related issues instead of an actual closed connection, in the case the connection is not yet restarted by the read loop, thus we disconnect in the keepalive loop instead.
- Adjusted some logging:
  - Command messages timing out are no longer ERROR level
  - Log at info level when connection is lost and restored
  - Log IncompleteReadError in the reading loop, for debugging purposes
  - Added more detailed debug logging in the keep alive loop

This should both fix https://github.com/home-assistant/core/issues/167759 and reduce the amount of re-connections that happen