### PR TITLE
Remove duplication between Read and Write commands

### DIFF
--- a/satel_integra/commands.py
+++ b/satel_integra/commands.py
@@ -15,17 +15,12 @@ class SatelBaseCommand(IntEnum):
         """Format command string as CMD [HEX]"""
         return f"{self.name} [0x{self.value:02X}]"
 
-    @property
-    def expects_same_cmd_response(self) -> bool:
-        return self in _ECHO_RESPONSE_COMMANDS
-
 
 @unique
 class SatelReadCommand(SatelBaseCommand):
-    """Read commands supported by Satel Integra protocol."""
+    """Read/query commands supported by Satel Integra protocol."""
 
     ZONES_VIOLATED = 0x00
-    ZONE_TEMPERATURE = 0x7D
     PARTITIONS_ARMED_SUPPRESSED = 0x09
     PARTITIONS_ARMED_MODE0 = 0x0A
     PARTITIONS_ARMED_MODE2 = 0x0B
@@ -36,16 +31,17 @@ class SatelReadCommand(SatelBaseCommand):
     PARTITIONS_ALARM = 0x13
     PARTITIONS_FIRE_ALARM = 0x14
     OUTPUTS_STATE = 0x17
+    RTC_AND_STATUS = 0x1A
     PARTITIONS_ARMED_MODE1 = 0x2A
+    ZONE_TEMPERATURE = 0x7D
     READ_DEVICE_NAME = 0xEE
     RESULT = 0xEF
 
 
 @unique
 class SatelWriteCommand(SatelBaseCommand):
-    """Write commands supported by Satel Integra protocol."""
+    """Action commands supported by Satel Integra protocol."""
 
-    ZONE_TEMPERATURE = 0x7D
     START_MONITORING = 0x7F
     PARTITIONS_ARM_MODE_0 = 0x80
     PARTITIONS_ARM_MODE_1 = 0x81
@@ -55,14 +51,16 @@ class SatelWriteCommand(SatelBaseCommand):
     PARTITIONS_CLEAR_ALARM = 0x85
     OUTPUTS_ON = 0x88
     OUTPUTS_OFF = 0x89
-    READ_DEVICE_NAME = 0xEE
-    RTC_AND_STATUS = 0x1A
 
 
-# Write commands that echo themselves back instead of returning RESULT
-_ECHO_RESPONSE_COMMANDS = frozenset(
-    {
-        SatelWriteCommand.ZONE_TEMPERATURE,
-        SatelWriteCommand.READ_DEVICE_NAME,
-    }
-)
+SatelOutboundCommand = SatelReadCommand | SatelWriteCommand
+
+
+def expected_response_command(command: SatelOutboundCommand) -> SatelReadCommand:
+    """Return the response command expected for an outbound command."""
+    if isinstance(command, SatelReadCommand):
+        if command is SatelReadCommand.RESULT:
+            raise ValueError("SatelReadCommand.RESULT cannot be sent as a command")
+        return command
+
+    return SatelReadCommand.RESULT

--- a/satel_integra/commands.py
+++ b/satel_integra/commands.py
@@ -42,6 +42,8 @@ class SatelReadCommand(SatelBaseCommand):
 class SatelWriteCommand(SatelBaseCommand):
     """Action commands supported by Satel Integra protocol."""
 
+    RTC_AND_STATUS = 0x1A
+    ZONE_TEMPERATURE = 0x7D
     START_MONITORING = 0x7F
     PARTITIONS_ARM_MODE_0 = 0x80
     PARTITIONS_ARM_MODE_1 = 0x81
@@ -51,9 +53,16 @@ class SatelWriteCommand(SatelBaseCommand):
     PARTITIONS_CLEAR_ALARM = 0x85
     OUTPUTS_ON = 0x88
     OUTPUTS_OFF = 0x89
+    READ_DEVICE_NAME = 0xEE
 
 
 SatelOutboundCommand = SatelReadCommand | SatelWriteCommand
+
+DEPRECATED_QUERY_WRITE_COMMANDS: dict[SatelWriteCommand, SatelReadCommand] = {
+    SatelWriteCommand.RTC_AND_STATUS: SatelReadCommand.RTC_AND_STATUS,
+    SatelWriteCommand.ZONE_TEMPERATURE: SatelReadCommand.ZONE_TEMPERATURE,
+    SatelWriteCommand.READ_DEVICE_NAME: SatelReadCommand.READ_DEVICE_NAME,
+}
 
 
 def expected_response_command(command: SatelOutboundCommand) -> SatelReadCommand:
@@ -62,5 +71,8 @@ def expected_response_command(command: SatelOutboundCommand) -> SatelReadCommand
         if command is SatelReadCommand.RESULT:
             raise ValueError("SatelReadCommand.RESULT cannot be sent as a command")
         return command
+
+    if command in DEPRECATED_QUERY_WRITE_COMMANDS:
+        return DEPRECATED_QUERY_WRITE_COMMANDS[command]
 
     return SatelReadCommand.RESULT

--- a/satel_integra/connection.py
+++ b/satel_integra/connection.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 
-from satel_integra.commands import SatelWriteCommand
+from satel_integra.commands import SatelReadCommand
 from satel_integra.const import MESSAGE_RESPONSE_TIMEOUT, ConnectionStateCallback
 from satel_integra.exceptions import (
     SatelConnectFailedError,
@@ -268,7 +268,7 @@ class SatelConnection:
             )
 
         try:
-            probe = SatelWriteMessage(SatelWriteCommand.RTC_AND_STATUS)
+            probe = SatelWriteMessage(SatelReadCommand.RTC_AND_STATUS)
 
             await self.send_frame(probe.encode_frame())
             raw_response = await asyncio.wait_for(

--- a/satel_integra/messages.py
+++ b/satel_integra/messages.py
@@ -3,7 +3,11 @@
 import logging
 from typing import TypeVar
 
-from satel_integra.commands import SatelBaseCommand, SatelReadCommand, SatelWriteCommand
+from satel_integra.commands import (
+    SatelBaseCommand,
+    SatelOutboundCommand,
+    SatelReadCommand,
+)
 from satel_integra.const import (
     FRAME_END,
     FRAME_SPECIAL_BYTES,
@@ -36,17 +40,20 @@ class SatelBaseMessage[TCommand: SatelBaseCommand]:
         return f"({self.__class__.__name__}) {self.cmd} -> {self.msg_data.hex()} ({len(self.msg_data)})"
 
 
-class SatelWriteMessage(SatelBaseMessage[SatelWriteCommand]):
+class SatelWriteMessage(SatelBaseMessage[SatelOutboundCommand]):
     """Message used to send commands to the panel."""
 
     def __init__(
         self,
-        cmd: SatelWriteCommand,
+        cmd: SatelOutboundCommand,
         code: str | None = None,
         partitions: list[int] | None = None,
         zones_or_outputs: list[int] | None = None,
         raw_data: bytearray | None = None,
     ) -> None:
+        if cmd is SatelReadCommand.RESULT:
+            raise ValueError("SatelReadCommand.RESULT cannot be sent as a command")
+
         msg_data = bytearray()
 
         if raw_data is not None:

--- a/satel_integra/messages.py
+++ b/satel_integra/messages.py
@@ -2,11 +2,14 @@
 
 import logging
 from typing import TypeVar
+from warnings import warn
 
 from satel_integra.commands import (
+    DEPRECATED_QUERY_WRITE_COMMANDS,
     SatelBaseCommand,
     SatelOutboundCommand,
     SatelReadCommand,
+    SatelWriteCommand,
 )
 from satel_integra.const import (
     FRAME_END,
@@ -53,6 +56,17 @@ class SatelWriteMessage(SatelBaseMessage[SatelOutboundCommand]):
     ) -> None:
         if cmd is SatelReadCommand.RESULT:
             raise ValueError("SatelReadCommand.RESULT cannot be sent as a command")
+        if (
+            isinstance(cmd, SatelWriteCommand)
+            and cmd in DEPRECATED_QUERY_WRITE_COMMANDS
+        ):
+            replacement = DEPRECATED_QUERY_WRITE_COMMANDS[cmd]
+            warn(
+                f"{cmd.__class__.__name__}.{cmd.name} is deprecated for query "
+                f"commands; use SatelReadCommand.{replacement.name} instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         msg_data = bytearray()
 

--- a/satel_integra/queue.py
+++ b/satel_integra/queue.py
@@ -152,18 +152,23 @@ class SatelMessageQueue:
 
     def on_message_received(self, result: SatelReadMessage) -> None:
         """Handle a message if it is relevant to the current queued command."""
-        if result.cmd is SatelReadCommand.RESULT or (
-            self._current_message is not None
-            and self._current_message.expected_result_command == result.cmd
+        if self._current_message is None:
+            # Received a message but no command is being processed.
+            # These are likely standard read messages reported by the monitoring.
+            if result.cmd is SatelReadCommand.RESULT:
+                _LOGGER.debug(
+                    "Received RESULT with no pending queued message: %s", result
+                )
+            return
+
+        if (
+            result.cmd is SatelReadCommand.RESULT
+            or self._current_message.expected_result_command == result.cmd
         ):
             self._complete_message(result)
 
     def _complete_message(self, result: SatelReadMessage) -> None:
         """Complete the current queued command with its response."""
-        if not self._current_message:
-            # Received a response but no command is being processed, likely monitoring.
-            return
-
         if self._current_message.processed_future.done():
             _LOGGER.debug(
                 "Received result but future is already done (likely timed out)"

--- a/satel_integra/queue.py
+++ b/satel_integra/queue.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 
-from satel_integra.commands import SatelReadCommand
+from satel_integra.commands import expected_response_command
 from satel_integra.const import MESSAGE_RESPONSE_TIMEOUT
 from satel_integra.messages import SatelReadMessage, SatelWriteMessage
 
@@ -20,12 +20,7 @@ class QueuedMessage:
             asyncio.get_running_loop().create_future()
         )
 
-        # Determine the expected response
-        self.expected_result_command = (
-            message.cmd
-            if getattr(message.cmd, "expects_same_cmd_response", False)
-            else SatelReadCommand.RESULT
-        )
+        self.expected_result_command = expected_response_command(message.cmd)
 
 
 class SatelMessageQueue:
@@ -127,7 +122,7 @@ class SatelMessageQueue:
             return None
 
     async def _send_and_wait_response(self, queued: QueuedMessage) -> None:
-        """Send a queued message and wait for the panel RESULT."""
+        """Send a queued message and wait for its response."""
 
         try:
             _LOGGER.debug("Sending message: %s", queued.message)
@@ -139,7 +134,7 @@ class SatelMessageQueue:
 
             return
 
-        # Wait for the RESULT (the future will be completed by on_message_received).
+        # Wait for the expected response. The future is completed by on_message_received().
         try:
             await asyncio.wait_for(
                 queued.processed_future, timeout=MESSAGE_RESPONSE_TIMEOUT

--- a/satel_integra/queue.py
+++ b/satel_integra/queue.py
@@ -139,6 +139,7 @@ class SatelMessageQueue:
             await asyncio.wait_for(
                 queued.processed_future, timeout=MESSAGE_RESPONSE_TIMEOUT
             )
+            _LOGGER.debug("Queued message resolved: %s", queued.message)
         except asyncio.TimeoutError:
             _LOGGER.debug(
                 "No response received from panel within %ss for message: %s",

--- a/satel_integra/queue.py
+++ b/satel_integra/queue.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 
-from satel_integra.commands import expected_response_command
+from satel_integra.commands import SatelReadCommand, expected_response_command
 from satel_integra.const import MESSAGE_RESPONSE_TIMEOUT
 from satel_integra.messages import SatelReadMessage, SatelWriteMessage
 
@@ -149,10 +149,18 @@ class SatelMessageQueue:
                 queued.processed_future.cancel()
             return
 
-    def on_message_received(self, result: SatelReadMessage):
-        """Called by AsyncSatel when a RESULT message is received."""
+    def on_message_received(self, result: SatelReadMessage) -> None:
+        """Handle a message if it is relevant to the current queued command."""
+        if result.cmd is SatelReadCommand.RESULT or (
+            self._current_message is not None
+            and self._current_message.expected_result_command == result.cmd
+        ):
+            self._complete_message(result)
+
+    def _complete_message(self, result: SatelReadMessage) -> None:
+        """Complete the current queued command with its response."""
         if not self._current_message:
-            # Received result but no message is being processed, standard read message due to monitoring
+            # Received a response but no command is being processed, likely monitoring.
             return
 
         if self._current_message.processed_future.done():

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -352,11 +352,7 @@ class AsyncSatel:
                 if not msg:
                     continue
 
-                # Only notify queue of command responses
-                if msg.cmd == SatelReadCommand.RESULT or getattr(
-                    msg.cmd, "expects_same_cmd_response", False
-                ):
-                    self._queue.on_message_received(msg)
+                self._queue.on_message_received(msg)
 
                 if msg.cmd in self._message_handlers:
                     _LOGGER.debug("Calling handler for command: %s", msg.cmd)

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -302,7 +302,7 @@ class AsyncSatel:
                 continue
 
             data = SatelWriteMessage(
-                SatelWriteCommand.READ_DEVICE_NAME, raw_data=bytearray([0x01, 0x01])
+                SatelReadCommand.READ_DEVICE_NAME, raw_data=bytearray([0x01, 0x01])
             )
             _LOGGER.debug(
                 "Keepalive sending after %.3fs of outbound inactivity", idle_for
@@ -478,7 +478,7 @@ class AsyncSatel:
         """Read the temperature for a single zone sensor."""
         request_zone_id = encode_zone_number(zone_id)
         msg = SatelWriteMessage(
-            SatelWriteCommand.ZONE_TEMPERATURE, raw_data=bytearray([request_zone_id])
+            SatelReadCommand.ZONE_TEMPERATURE, raw_data=bytearray([request_zone_id])
         )
         response = await self._send_data_and_wait(msg)
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -4,6 +4,7 @@ from satel_integra.commands import SatelReadCommand
 from satel_integra.const import FRAME_END, FRAME_START
 from satel_integra.messages import (
     SatelReadMessage,
+    SatelWriteMessage,
     SatelZoneTemperatureReadMessage,
 )
 from satel_integra.utils import checksum
@@ -31,3 +32,17 @@ def test_zone_temperature_message_validates_payload_length() -> None:
         SatelZoneTemperatureReadMessage(
             SatelReadCommand.ZONE_TEMPERATURE, bytearray([1, 0x00])
         )
+
+
+def test_write_message_encodes_read_query_command() -> None:
+    msg = SatelWriteMessage(SatelReadCommand.RTC_AND_STATUS)
+    frame = msg.encode_frame()
+
+    assert frame.startswith(bytearray(FRAME_START))
+    assert frame[2] == SatelReadCommand.RTC_AND_STATUS
+    assert frame.endswith(bytearray(FRAME_END))
+
+
+def test_write_message_rejects_result_command() -> None:
+    with pytest.raises(ValueError, match="RESULT cannot be sent"):
+        SatelWriteMessage(SatelReadCommand.RESULT)

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,6 +1,6 @@
 import pytest
 
-from satel_integra.commands import SatelReadCommand
+from satel_integra.commands import SatelReadCommand, SatelWriteCommand
 from satel_integra.const import FRAME_END, FRAME_START
 from satel_integra.messages import (
     SatelReadMessage,
@@ -46,3 +46,10 @@ def test_write_message_encodes_read_query_command() -> None:
 def test_write_message_rejects_result_command() -> None:
     with pytest.raises(ValueError, match="RESULT cannot be sent"):
         SatelWriteMessage(SatelReadCommand.RESULT)
+
+
+def test_write_message_warns_for_deprecated_write_query_command() -> None:
+    with pytest.warns(DeprecationWarning, match="SatelReadCommand.ZONE_TEMPERATURE"):
+        SatelWriteMessage(
+            SatelWriteCommand.ZONE_TEMPERATURE, raw_data=bytearray([0x01])
+        )

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -273,6 +273,16 @@ async def test_on_message_received_no_current_message(mock_queue, result_msg):
 
 
 @pytest.mark.asyncio
+async def test_on_message_received_logs_result_without_current_message(
+    mock_queue, result_msg, caplog
+):
+    with caplog.at_level(logging.DEBUG):
+        mock_queue.on_message_received(result_msg)
+
+    assert "Received RESULT with no pending queued message" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_on_message_received_future_already_done(
     mock_queue, write_msg, result_msg, caplog
 ):

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -96,11 +96,25 @@ async def test_queued_message_init(write_msg):
 
 @pytest.mark.asyncio
 async def test_queued_message_init_same_cmd():
-    write_msg = SatelWriteMessage(SatelWriteCommand.READ_DEVICE_NAME)
+    write_msg = SatelWriteMessage(SatelReadCommand.READ_DEVICE_NAME)
     message = QueuedMessage(write_msg, True)
 
     assert message.return_result is True
-    assert message.expected_result_command is SatelWriteCommand.READ_DEVICE_NAME
+    assert message.expected_result_command is SatelReadCommand.READ_DEVICE_NAME
+
+
+@pytest.mark.asyncio
+async def test_queued_message_init_rtc_and_status_expects_same_cmd():
+    write_msg = SatelWriteMessage(SatelReadCommand.RTC_AND_STATUS)
+    message = QueuedMessage(write_msg, True)
+
+    assert message.expected_result_command is SatelReadCommand.RTC_AND_STATUS
+
+
+@pytest.mark.asyncio
+async def test_queued_message_rejects_result_as_outbound_command():
+    with pytest.raises(ValueError, match="RESULT cannot be sent"):
+        SatelWriteMessage(SatelReadCommand.RESULT)
 
 
 @pytest.mark.asyncio
@@ -181,7 +195,7 @@ async def test_on_message_received_correct(mock_queue, write_msg, result_msg):
 async def test_on_message_received_commmand_mismatch(mock_queue, result_msg, caplog):
     caplog.at_level(logging.WARNING)
 
-    queued = QueuedMessage(SatelWriteMessage(SatelWriteCommand.READ_DEVICE_NAME), True)
+    queued = QueuedMessage(SatelWriteMessage(SatelReadCommand.READ_DEVICE_NAME), True)
     mock_queue._current_message = queued
     mock_queue.on_message_received(result_msg)
 
@@ -190,6 +204,54 @@ async def test_on_message_received_commmand_mismatch(mock_queue, result_msg, cap
         in caplog.text
     )
 
+    assert not queued.processed_future.done()
+
+
+@pytest.mark.asyncio
+async def test_on_message_received_completes_current_expected_command(mock_queue):
+    queued = QueuedMessage(SatelWriteMessage(SatelReadCommand.RTC_AND_STATUS), True)
+    mock_queue._current_message = queued
+    msg = SatelReadMessage(SatelReadCommand.RTC_AND_STATUS, bytearray())
+
+    mock_queue.on_message_received(msg)
+
+    assert queued.processed_future.done()
+
+
+@pytest.mark.asyncio
+async def test_on_message_received_logs_unrelated_read_command(mock_queue, caplog):
+    caplog.at_level(logging.WARNING)
+    queued = QueuedMessage(SatelWriteMessage(SatelReadCommand.RTC_AND_STATUS), True)
+    mock_queue._current_message = queued
+    msg = SatelReadMessage(SatelReadCommand.ZONES_VIOLATED, bytearray())
+
+    mock_queue.on_message_received(msg)
+
+    assert "expects different result" not in caplog.text
+    assert not queued.processed_future.done()
+
+
+@pytest.mark.asyncio
+async def test_complete_message_completes_current_expected_command(mock_queue):
+    queued = QueuedMessage(SatelWriteMessage(SatelReadCommand.RTC_AND_STATUS), True)
+    mock_queue._current_message = queued
+    msg = SatelReadMessage(SatelReadCommand.RTC_AND_STATUS, bytearray())
+
+    mock_queue._complete_message(msg)
+
+    assert queued.processed_future.done()
+
+
+@pytest.mark.asyncio
+async def test_complete_message_logs_unrelated_read_command(mock_queue, caplog):
+    caplog.at_level(logging.WARNING)
+    queued = QueuedMessage(SatelWriteMessage(SatelReadCommand.RTC_AND_STATUS), True)
+    mock_queue._current_message = queued
+    msg = SatelReadMessage(SatelReadCommand.ZONES_VIOLATED, bytearray())
+
+    mock_queue._complete_message(msg)
+
+    assert "expects different result" in caplog.text
     assert not queued.processed_future.done()
 
 
@@ -272,16 +334,20 @@ async def test_process_queue_skips_none(mock_queue):
 
 
 @pytest.mark.asyncio
-async def test_send_and_wait_response_success(mock_queue, write_msg, result_msg):
+async def test_send_and_wait_response_success(
+    mock_queue, write_msg, result_msg, caplog
+):
     mock_queue._send_func = AsyncMock()
 
     queued = QueuedMessage(write_msg, False)
     queued.processed_future.set_result(result_msg)
 
-    await mock_queue._send_and_wait_response(queued)
+    with caplog.at_level(logging.DEBUG):
+        await mock_queue._send_and_wait_response(queued)
 
     mock_queue._send_func.assert_awaited_once_with(write_msg)
 
+    assert "Queued message resolved:" in caplog.text
     assert queued.processed_future.done()
 
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -112,6 +112,16 @@ async def test_queued_message_init_rtc_and_status_expects_same_cmd():
 
 
 @pytest.mark.asyncio
+async def test_deprecated_write_query_command_expects_matching_read_response():
+    with pytest.warns(DeprecationWarning, match="SatelReadCommand.RTC_AND_STATUS"):
+        write_msg = SatelWriteMessage(SatelWriteCommand.RTC_AND_STATUS)
+
+    message = QueuedMessage(write_msg, True)
+
+    assert message.expected_result_command is SatelReadCommand.RTC_AND_STATUS
+
+
+@pytest.mark.asyncio
 async def test_queued_message_rejects_result_as_outbound_command():
     with pytest.raises(ValueError, match="RESULT cannot be sent"):
         SatelWriteMessage(SatelReadCommand.RESULT)

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -61,6 +61,7 @@ def satel(monkeypatch, mock_connection, mock_queue):
     )
     satel._connection = mock_connection
     satel._queue = mock_queue
+    mock_queue.on_message_received = MagicMock()
     return satel
 
 
@@ -214,6 +215,8 @@ async def test_read_temperature_returns_expected_value(
 
     assert result == expected
     mock_queue.add_message.assert_awaited_once()
+    sent_msg = mock_queue.add_message.await_args.args[0]
+    assert sent_msg.cmd is SatelReadCommand.ZONE_TEMPERATURE
 
 
 @pytest.mark.asyncio
@@ -457,6 +460,40 @@ async def test_reading_loop_processes_message(satel, mock_connection):
     await satel._reading_loop()
 
     cmd_handler.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_reading_loop_forwards_expected_read_response_to_queue(
+    satel, mock_connection, mock_queue
+):
+    msg = MagicMock()
+    msg.cmd = SatelReadCommand.RTC_AND_STATUS
+
+    satel._connection.ensure_connected = AsyncMock(
+        side_effect=[None, SatelConnectionStoppedError]
+    )
+    satel._read_data = AsyncMock(return_value=msg)
+
+    await satel._reading_loop()
+
+    mock_queue.on_message_received.assert_called_once_with(msg)
+
+
+@pytest.mark.asyncio
+async def test_reading_loop_forwards_unexpected_read_response_to_queue_filter(
+    satel, mock_connection, mock_queue
+):
+    msg = MagicMock()
+    msg.cmd = SatelReadCommand.ZONES_VIOLATED
+
+    satel._connection.ensure_connected = AsyncMock(
+        side_effect=[None, SatelConnectionStoppedError]
+    )
+    satel._read_data = AsyncMock(return_value=msg)
+
+    await satel._reading_loop()
+
+    mock_queue.on_message_received.assert_called_once_with(msg)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Whenever a new command needs to be added, which can returns it's own command code as a result (basically any Read command), this command needs to be added on both the Write and Read enums.

This PR improves the logic around that, every Read command is also implicit a Write command, as any of these commands can be send to the panel to retrieve the specific status for that command.
The exception being RESULT, which is an actual result for actual Write commands.

There is a compatibility layer in place, to allow external callers of the code to adjust their references. These classes are seen as internal though (not exported from top level), so this is mainly a short safety net.