### PR TITLE
Add ability to read zone information

### DIFF
--- a/satel_integra/__init__.py
+++ b/satel_integra/__init__.py
@@ -12,9 +12,12 @@ from .exceptions import (
 )
 from .models import (
     SatelCommunicationModuleInfo,
+    SatelDeviceInfo,
+    SatelDeviceKind,
     SatelFirmwareVersion,
     SatelPanelInfo,
     SatelPanelModel,
+    SatelZoneInfo,
 )
 from .satel_integra import AlarmState, AsyncSatel
 
@@ -22,6 +25,8 @@ __all__ = [
     "AlarmState",
     "AsyncSatel",
     "SatelCommunicationModuleInfo",
+    "SatelDeviceInfo",
+    "SatelDeviceKind",
     "SatelFirmwareVersion",
     "SatelPanelModel",
     "SatelConnectFailedError",
@@ -33,4 +38,5 @@ __all__ = [
     "SatelPanelInfo",
     "SatelPanelBusyError",
     "SatelUnexpectedResponseError",
+    "SatelZoneInfo",
 ]

--- a/satel_integra/__init__.py
+++ b/satel_integra/__init__.py
@@ -13,7 +13,7 @@ from .exceptions import (
 from .models import (
     SatelCommunicationModuleInfo,
     SatelDeviceInfo,
-    SatelDeviceKind,
+    SatelDeviceType,
     SatelFirmwareVersion,
     SatelPanelInfo,
     SatelPanelModel,
@@ -26,7 +26,7 @@ __all__ = [
     "AsyncSatel",
     "SatelCommunicationModuleInfo",
     "SatelDeviceInfo",
-    "SatelDeviceKind",
+    "SatelDeviceType",
     "SatelFirmwareVersion",
     "SatelPanelModel",
     "SatelConnectFailedError",

--- a/satel_integra/messages.py
+++ b/satel_integra/messages.py
@@ -1,6 +1,7 @@
 """Message classes for communication with Satel Integra panel."""
 
 import logging
+from enum import IntEnum, unique
 from typing import ClassVar, TypeVar
 from warnings import warn
 
@@ -35,6 +36,32 @@ _LOGGER = logging.getLogger(__name__)
 
 
 TCommand = TypeVar("TCommand", bound=SatelBaseCommand)
+
+
+@unique
+class SatelDeviceSelector(IntEnum):
+    """Raw 0xEE device selectors used on the wire."""
+
+    ZONE_WITH_PARTITION_ASSIGNMENT = 0x05
+
+
+def _decode_device_read_message(
+    cmd: SatelReadCommand, msg_data: bytearray
+) -> "SatelReadMessage":
+    """Decode a 0xEE device response into the appropriate message type."""
+    if not msg_data:
+        raise SatelUnexpectedResponseError(
+            "READ_DEVICE_NAME response missing device type"
+        )
+
+    if msg_data[0] != SatelDeviceSelector.ZONE_WITH_PARTITION_ASSIGNMENT:
+        _LOGGER.debug(
+            "Unsupported READ_DEVICE_NAME device type: 0x%02X; using default read message",
+            msg_data[0],
+        )
+        return SatelReadMessage(cmd, msg_data)
+
+    return SatelZoneInfoReadMessage(cmd, msg_data)
 
 
 class SatelBaseMessage[TCommand: SatelBaseCommand]:
@@ -135,18 +162,21 @@ class SatelReadMessage(SatelBaseMessage[SatelReadCommand]):
         cmd_byte, data = output[0], output[1:-2]
         try:
             cmd = SatelReadCommand(cmd_byte)
-            match cmd:
-                case SatelReadCommand.MODULE_VERSION:
-                    return SatelModuleVersionReadMessage(cmd, bytearray(data))
-                case SatelReadCommand.ZONE_TEMPERATURE:
-                    return SatelZoneTemperatureReadMessage(cmd, bytearray(data))
-                case SatelReadCommand.INTEGRA_VERSION:
-                    return SatelIntegraVersionReadMessage(cmd, bytearray(data))
-                case _:
-                    return SatelReadMessage(cmd, bytearray(data))
         except ValueError as ex:
             _LOGGER.error("Unknown command byte: %s", hex(cmd_byte))
             raise ValueError("Unknown command byte") from ex
+
+        match cmd:
+            case SatelReadCommand.MODULE_VERSION:
+                return SatelModuleVersionReadMessage(cmd, bytearray(data))
+            case SatelReadCommand.ZONE_TEMPERATURE:
+                return SatelZoneTemperatureReadMessage(cmd, bytearray(data))
+            case SatelReadCommand.INTEGRA_VERSION:
+                return SatelIntegraVersionReadMessage(cmd, bytearray(data))
+            case SatelReadCommand.READ_DEVICE_NAME:
+                return _decode_device_read_message(cmd, bytearray(data))
+            case _:
+                return SatelReadMessage(cmd, bytearray(data))
 
     def get_active_bits(self, expected_length: int) -> list[int]:
         """Convenience wrapper around decode_bitmask_le() for this message."""

--- a/satel_integra/messages.py
+++ b/satel_integra/messages.py
@@ -18,7 +18,11 @@ from satel_integra.const import (
     FRAME_START,
 )
 from satel_integra.exceptions import SatelUnexpectedResponseError
-from satel_integra.models import SatelCommunicationModuleInfo, SatelPanelInfo
+from satel_integra.models import (
+    SatelCommunicationModuleInfo,
+    SatelPanelInfo,
+    SatelZoneInfo,
+)
 from satel_integra.utils import (
     checksum,
     decode_bitmask_le,
@@ -201,3 +205,14 @@ class SatelIntegraVersionReadMessage(SatelReadMessage):
     def panel_info(self) -> SatelPanelInfo:
         """Return parsed INTEGRA panel information."""
         return SatelPanelInfo._from_payload(self.msg_data)
+
+
+class SatelZoneInfoReadMessage(SatelReadMessage):
+    """Structured read message for a 0xEE zone info response."""
+
+    expected_data_length = 20
+
+    @property
+    def device_info(self) -> SatelZoneInfo:
+        """Return parsed zone information."""
+        return SatelZoneInfo._from_payload(self.msg_data)

--- a/satel_integra/messages.py
+++ b/satel_integra/messages.py
@@ -2,6 +2,7 @@
 
 import logging
 from enum import IntEnum, unique
+from functools import cached_property
 from typing import ClassVar, TypeVar
 from warnings import warn
 
@@ -204,12 +205,12 @@ class SatelZoneTemperatureReadMessage(SatelReadMessage):
 
     expected_data_length = 3
 
-    @property
+    @cached_property
     def zone_id(self) -> int:
         """Return the decoded zone id for this temperature response."""
         return decode_zone_number(self.msg_data[0])
 
-    @property
+    @cached_property
     def temperature(self) -> float | None:
         """Return the decoded temperature in Celsius."""
         return decode_temperature(self.msg_data[1], self.msg_data[2])
@@ -220,7 +221,7 @@ class SatelModuleVersionReadMessage(SatelReadMessage):
 
     expected_data_length = 12
 
-    @property
+    @cached_property
     def module_info(self) -> SatelCommunicationModuleInfo:
         """Return parsed communication module information."""
         return SatelCommunicationModuleInfo._from_payload(self.msg_data)
@@ -231,7 +232,7 @@ class SatelIntegraVersionReadMessage(SatelReadMessage):
 
     expected_data_length = 14
 
-    @property
+    @cached_property
     def panel_info(self) -> SatelPanelInfo:
         """Return parsed INTEGRA panel information."""
         return SatelPanelInfo._from_payload(self.msg_data)
@@ -242,7 +243,7 @@ class SatelZoneInfoReadMessage(SatelReadMessage):
 
     expected_data_length = 20
 
-    @property
+    @cached_property
     def device_info(self) -> SatelZoneInfo:
         """Return parsed zone information."""
         return SatelZoneInfo._from_payload(self.msg_data)

--- a/satel_integra/models/__init__.py
+++ b/satel_integra/models/__init__.py
@@ -1,6 +1,6 @@
 """Public data models for Satel Integra."""
 
-from .device import SatelDeviceInfo, SatelDeviceKind
+from .device import SatelDeviceInfo, SatelDeviceType
 from .firmware import SatelFirmwareVersion
 from .module import SatelCommunicationModuleInfo
 from .panel import SatelPanelInfo, SatelPanelModel
@@ -9,7 +9,7 @@ from .zone import SatelZoneInfo
 __all__ = [
     "SatelCommunicationModuleInfo",
     "SatelDeviceInfo",
-    "SatelDeviceKind",
+    "SatelDeviceType",
     "SatelFirmwareVersion",
     "SatelPanelInfo",
     "SatelPanelModel",

--- a/satel_integra/models/__init__.py
+++ b/satel_integra/models/__init__.py
@@ -1,5 +1,6 @@
 """Public data models for Satel Integra."""
 
+from .device import SatelDeviceInfo, SatelDeviceKind
 from .firmware import SatelFirmwareVersion
 from .module import SatelCommunicationModuleInfo
 from .panel import SatelPanelInfo, SatelPanelModel
@@ -7,6 +8,8 @@ from .zone import SatelZoneInfo
 
 __all__ = [
     "SatelCommunicationModuleInfo",
+    "SatelDeviceInfo",
+    "SatelDeviceKind",
     "SatelFirmwareVersion",
     "SatelPanelInfo",
     "SatelPanelModel",

--- a/satel_integra/models/__init__.py
+++ b/satel_integra/models/__init__.py
@@ -3,10 +3,12 @@
 from .firmware import SatelFirmwareVersion
 from .module import SatelCommunicationModuleInfo
 from .panel import SatelPanelInfo, SatelPanelModel
+from .zone import SatelZoneInfo
 
 __all__ = [
     "SatelCommunicationModuleInfo",
     "SatelFirmwareVersion",
     "SatelPanelInfo",
     "SatelPanelModel",
+    "SatelZoneInfo",
 ]

--- a/satel_integra/models/device.py
+++ b/satel_integra/models/device.py
@@ -1,0 +1,29 @@
+"""Shared device information models."""
+
+from dataclasses import dataclass
+from enum import Enum, unique
+
+
+@unique
+class SatelDeviceKind(Enum):
+    """Semantic device kinds returned by 0xEE reads."""
+
+    PARTITION = "partition"
+    ZONE = "zone"
+    USER = "user"
+    EXPANDER_OR_LCD = "expander_or_lcd"
+    OUTPUT = "output"
+
+
+@dataclass(frozen=True)
+class SatelDeviceInfo:
+    """Shared fields present in 0xEE device information responses."""
+
+    kind: SatelDeviceKind
+    number: int
+    name: str
+
+    @staticmethod
+    def _decode_name(payload: bytes) -> str:
+        """Decode the shared 0xEE device name field."""
+        return payload[3:19].decode("latin-1").rstrip("\x00 ").strip()

--- a/satel_integra/models/device.py
+++ b/satel_integra/models/device.py
@@ -5,21 +5,17 @@ from enum import Enum, unique
 
 
 @unique
-class SatelDeviceKind(Enum):
-    """Semantic device kinds returned by 0xEE reads."""
+class SatelDeviceType(Enum):
+    """Semantic device types returned by 0xEE reads."""
 
-    PARTITION = "partition"
     ZONE = "zone"
-    USER = "user"
-    EXPANDER_OR_LCD = "expander_or_lcd"
-    OUTPUT = "output"
 
 
 @dataclass(frozen=True)
 class SatelDeviceInfo:
     """Shared fields present in 0xEE device information responses."""
 
-    kind: SatelDeviceKind
+    device_type: SatelDeviceType
     number: int
     name: str
 

--- a/satel_integra/models/zone.py
+++ b/satel_integra/models/zone.py
@@ -1,27 +1,26 @@
 """Structured zone information."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from satel_integra.utils import decode_zone_number
 
+from .device import SatelDeviceInfo, SatelDeviceKind
+
 
 @dataclass(frozen=True)
-class SatelZoneInfo:
+class SatelZoneInfo(SatelDeviceInfo):
     """Information returned by the 0xEE zone name read command."""
 
-    number: int
-    name: str
+    kind: SatelDeviceKind = field(default=SatelDeviceKind.ZONE, init=False)
     type_code: int
     partition_assignment: int | None
 
     @classmethod
     def _from_payload(cls, payload: bytes) -> "SatelZoneInfo":
         """Parse a 0xEE zone payload with partition assignment."""
-        name = payload[3:19].decode("latin-1").rstrip("\x00 ").strip()
-
         return cls(
             number=decode_zone_number(payload[1]),
-            name=name,
+            name=cls._decode_name(payload),
             type_code=payload[2],
             partition_assignment=payload[19] if payload[19] else None,
         )

--- a/satel_integra/models/zone.py
+++ b/satel_integra/models/zone.py
@@ -4,14 +4,14 @@ from dataclasses import dataclass, field
 
 from satel_integra.utils import decode_zone_number
 
-from .device import SatelDeviceInfo, SatelDeviceKind
+from .device import SatelDeviceInfo, SatelDeviceType
 
 
 @dataclass(frozen=True)
 class SatelZoneInfo(SatelDeviceInfo):
     """Information returned by the 0xEE zone name read command."""
 
-    kind: SatelDeviceKind = field(default=SatelDeviceKind.ZONE, init=False)
+    device_type: SatelDeviceType = field(default=SatelDeviceType.ZONE, init=False)
     type_code: int
     partition_assignment: int | None
 

--- a/satel_integra/models/zone.py
+++ b/satel_integra/models/zone.py
@@ -1,0 +1,27 @@
+"""Structured zone information."""
+
+from dataclasses import dataclass
+
+from satel_integra.utils import decode_zone_number
+
+
+@dataclass(frozen=True)
+class SatelZoneInfo:
+    """Information returned by the 0xEE zone name read command."""
+
+    number: int
+    name: str
+    type_code: int
+    partition_assignment: int | None
+
+    @classmethod
+    def _from_payload(cls, payload: bytes) -> "SatelZoneInfo":
+        """Parse a 0xEE zone payload with partition assignment."""
+        name = payload[3:19].decode("latin-1").rstrip("\x00 ").strip()
+
+        return cls(
+            number=decode_zone_number(payload[1]),
+            name=name,
+            type_code=payload[2],
+            partition_assignment=payload[19] if payload[19] else None,
+        )

--- a/satel_integra/queue.py
+++ b/satel_integra/queue.py
@@ -182,6 +182,7 @@ class SatelMessageQueue:
                 self._current_message.message,
                 self._current_message.expected_result_command,
             )
-            return
+            if result.cmd is not SatelReadCommand.RESULT:
+                return
 
         self._current_message.processed_future.set_result(result)

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -495,6 +495,7 @@ class AsyncSatel:
 
         if response is None:
             return None
+
         if response.zone_id != zone_id:
             msg = (
                 "Temperature response zone mismatch: "
@@ -535,6 +536,7 @@ class AsyncSatel:
 
         if response is None:
             return None
+
         if response.device_info.number != zone_id:
             msg = (
                 "Zone info response zone mismatch: "
@@ -554,6 +556,7 @@ class AsyncSatel:
 
         if response is None:
             return None
+
         return response.panel_info
 
     async def read_communication_module_info(
@@ -568,6 +571,7 @@ class AsyncSatel:
 
         if response is None:
             return None
+
         return response.module_info
 
     # endregion
@@ -591,6 +595,9 @@ class AsyncSatel:
 
         if response is None:
             _LOGGER.debug(f"No response received for {msg.cmd}")
+            return None
+
+        if response.cmd is SatelReadCommand.RESULT:
             return None
 
         if not isinstance(response, expected_type):

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -19,15 +19,18 @@ from satel_integra.exceptions import (
     SatelUnexpectedResponseError,
 )
 from satel_integra.messages import (
+    SatelDeviceSelector,
     SatelIntegraVersionReadMessage,
     SatelModuleVersionReadMessage,
     SatelReadMessage,
     SatelWriteMessage,
+    SatelZoneInfoReadMessage,
     SatelZoneTemperatureReadMessage,
 )
 from satel_integra.models import (
     SatelCommunicationModuleInfo,
     SatelPanelInfo,
+    SatelZoneInfo,
 )
 from satel_integra.queue import SatelMessageQueue
 from satel_integra.utils import encode_bitmask_le, encode_zone_number
@@ -516,6 +519,34 @@ class AsyncSatel:
                 temperatures[zone_id] = None
 
         return temperatures
+
+    async def read_zone_info(self, zone_id: int) -> SatelZoneInfo | None:
+        """Read metadata for a single zone."""
+        request_zone_id = encode_zone_number(zone_id)
+        msg = SatelWriteMessage(
+            SatelReadCommand.READ_DEVICE_NAME,
+            raw_data=bytearray(
+                [SatelDeviceSelector.ZONE_WITH_PARTITION_ASSIGNMENT, request_zone_id]
+            ),
+        )
+        response = await self._send_data_and_wait(msg)
+
+        if response is None:
+            _LOGGER.debug("No zone info response for zone %s", zone_id)
+            return None
+
+        if not isinstance(response, SatelZoneInfoReadMessage):
+            msg = f"Unexpected response type for zone info read: {type(response).__name__}"
+            raise SatelUnexpectedResponseError(msg)
+
+        if response.device_info.number != zone_id:
+            msg = (
+                "Zone info response zone mismatch: "
+                f"expected {zone_id}, got {response.device_info.number}"
+            )
+            raise ValueError(msg)
+
+        return response.device_info
 
     async def read_panel_info(self) -> SatelPanelInfo | None:
         """Read structured panel information."""

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -5,7 +5,7 @@ import logging
 import sys
 from collections.abc import Awaitable, Callable
 from enum import Enum, unique
-from typing import overload
+from typing import TypeVar, overload
 from warnings import warn
 
 from satel_integra.commands import SatelReadCommand, SatelWriteCommand
@@ -34,6 +34,8 @@ from satel_integra.models import (
 )
 from satel_integra.queue import SatelMessageQueue
 from satel_integra.utils import encode_bitmask_le, encode_zone_number
+
+TReadMessage = TypeVar("TReadMessage", bound=SatelReadMessage)
 
 if sys.version_info >= (3, 13):
     from warnings import deprecated
@@ -486,16 +488,13 @@ class AsyncSatel:
         msg = SatelWriteMessage(
             SatelReadCommand.ZONE_TEMPERATURE, raw_data=bytearray([request_zone_id])
         )
-        response = await self._send_data_and_wait(msg)
+        response = await self._typed_send_data_and_wait(
+            msg,
+            SatelZoneTemperatureReadMessage,
+        )
 
         if response is None:
-            _LOGGER.debug("No temperature response for zone %s", zone_id)
             return None
-
-        if not isinstance(response, SatelZoneTemperatureReadMessage):
-            msg = f"Unexpected response type for temperature read: {type(response).__name__}"
-            raise SatelUnexpectedResponseError(msg)
-
         if response.zone_id != zone_id:
             msg = (
                 "Temperature response zone mismatch: "
@@ -529,16 +528,13 @@ class AsyncSatel:
                 [SatelDeviceSelector.ZONE_WITH_PARTITION_ASSIGNMENT, request_zone_id]
             ),
         )
-        response = await self._send_data_and_wait(msg)
+        response = await self._typed_send_data_and_wait(
+            msg,
+            SatelZoneInfoReadMessage,
+        )
 
         if response is None:
-            _LOGGER.debug("No zone info response for zone %s", zone_id)
             return None
-
-        if not isinstance(response, SatelZoneInfoReadMessage):
-            msg = f"Unexpected response type for zone info read: {type(response).__name__}"
-            raise SatelUnexpectedResponseError(msg)
-
         if response.device_info.number != zone_id:
             msg = (
                 "Zone info response zone mismatch: "
@@ -551,19 +547,13 @@ class AsyncSatel:
     async def read_panel_info(self) -> SatelPanelInfo | None:
         """Read structured panel information."""
         msg = SatelWriteMessage(SatelReadCommand.INTEGRA_VERSION)
+        response = await self._typed_send_data_and_wait(
+            msg,
+            SatelIntegraVersionReadMessage,
+        )
 
-        response = await self._send_data_and_wait(msg)
         if response is None:
-            _LOGGER.warning("No panel info response received")
             return None
-
-        if not isinstance(response, SatelIntegraVersionReadMessage):
-            msg = (
-                "Unexpected response type for INTEGRA version read: "
-                f"{type(response).__name__}"
-            )
-            raise SatelUnexpectedResponseError(msg)
-
         return response.panel_info
 
     async def read_communication_module_info(
@@ -571,19 +561,13 @@ class AsyncSatel:
     ) -> SatelCommunicationModuleInfo | None:
         """Read structured communication module information."""
         msg = SatelWriteMessage(SatelReadCommand.MODULE_VERSION)
+        response = await self._typed_send_data_and_wait(
+            msg,
+            SatelModuleVersionReadMessage,
+        )
 
-        response = await self._send_data_and_wait(msg)
         if response is None:
-            _LOGGER.warning("No communication module info response received")
             return None
-
-        if not isinstance(response, SatelModuleVersionReadMessage):
-            msg = (
-                "Unexpected response type for module version read: "
-                f"{type(response).__name__}"
-            )
-            raise SatelUnexpectedResponseError(msg)
-
         return response.module_info
 
     # endregion
@@ -596,6 +580,24 @@ class AsyncSatel:
     async def _send_data_and_wait(self, msg: SatelWriteMessage):
         """Add message to the queue and wait for the result."""
         return await self._queue.add_message(msg, True)
+
+    async def _typed_send_data_and_wait(
+        self,
+        msg: SatelWriteMessage,
+        expected_type: type[TReadMessage],
+    ) -> TReadMessage | None:
+        """Send a message and validate the response message type."""
+        response = await self._send_data_and_wait(msg)
+
+        if response is None:
+            _LOGGER.debug(f"No response received for {msg.cmd}")
+            return None
+
+        if not isinstance(response, expected_type):
+            err = f"Unexpected response type for {msg.cmd}: {type(response).__name__}"
+            raise SatelUnexpectedResponseError(err)
+
+        return response
 
     async def _send_encoded_frame(self, msg: SatelWriteMessage) -> None:
         """Encodes and actually sends message."""

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -10,22 +10,26 @@ from satel_integra.messages import (
     SatelModuleVersionReadMessage,
     SatelReadMessage,
     SatelWriteMessage,
+    SatelZoneInfoReadMessage,
     SatelZoneTemperatureReadMessage,
 )
 from satel_integra.utils import checksum
 
 
-def test_decode_frame_returns_zone_temperature_message() -> None:
-    payload = bytearray([0x7D, 0x01, 0x00, 0x96])
+def _frame_payload(payload: bytearray) -> bytearray:
     csum = checksum(payload)
-    frame = (
+    return (
         bytearray(FRAME_START)
         + payload
         + bytearray([csum >> 8, csum & 0xFF])
         + bytearray(FRAME_END)
     )
 
-    msg = SatelReadMessage.decode_frame(frame)
+
+def test_decode_frame_returns_zone_temperature_message() -> None:
+    payload = bytearray([SatelReadCommand.ZONE_TEMPERATURE, 0x01, 0x00, 0x96])
+
+    msg = SatelReadMessage.decode_frame(_frame_payload(payload))
 
     assert isinstance(msg, SatelZoneTemperatureReadMessage)
     assert msg.zone_id == 1
@@ -36,15 +40,8 @@ def test_decode_frame_returns_integra_version_message() -> None:
     payload = (
         bytearray([0x7E, 72]) + bytearray(b"12320120527") + bytearray([0x00, 0xFF])
     )
-    csum = checksum(payload)
-    frame = (
-        bytearray(FRAME_START)
-        + payload
-        + bytearray([csum >> 8, csum & 0xFF])
-        + bytearray(FRAME_END)
-    )
 
-    msg = SatelReadMessage.decode_frame(frame)
+    msg = SatelReadMessage.decode_frame(_frame_payload(payload))
 
     assert isinstance(msg, SatelIntegraVersionReadMessage)
     assert msg.panel_info.type_code == 72
@@ -56,17 +53,45 @@ def test_decode_frame_returns_integra_version_message() -> None:
     assert msg.panel_info.settings_stored_in_flash is True
 
 
-def test_decode_frame_returns_module_version_message() -> None:
-    payload = bytearray([0x7C]) + bytearray(b"12320120527") + bytearray([0b0000_0111])
-    csum = checksum(payload)
-    frame = (
-        bytearray(FRAME_START)
-        + payload
-        + bytearray([csum >> 8, csum & 0xFF])
-        + bytearray(FRAME_END)
+def test_decode_frame_returns_zone_info_message() -> None:
+    payload = (
+        bytearray([0xEE, 0x05, 0x01, 0x2A])
+        + bytearray(b"Front Door      ")
+        + bytearray([0x03])
     )
 
-    msg = SatelReadMessage.decode_frame(frame)
+    msg = SatelReadMessage.decode_frame(_frame_payload(payload))
+
+    assert isinstance(msg, SatelZoneInfoReadMessage)
+    assert msg.msg_data == payload[1:]
+
+
+def test_decode_frame_returns_default_message_for_unknown_device_type(caplog) -> None:
+    payload = bytearray([0xEE, 0x04, 0x01, 0x10]) + bytearray(b"Output 1        ")
+
+    with caplog.at_level(logging.DEBUG):
+        msg = SatelReadMessage.decode_frame(_frame_payload(payload))
+
+    assert type(msg) is SatelReadMessage
+    assert msg.cmd is SatelReadCommand.READ_DEVICE_NAME
+    assert msg.msg_data == payload[1:]
+    assert "Unsupported READ_DEVICE_NAME device type: 0x04" in caplog.text
+
+
+def test_decode_frame_rejects_missing_device_type() -> None:
+    payload = bytearray([0xEE])
+
+    with pytest.raises(
+        SatelUnexpectedResponseError,
+        match="READ_DEVICE_NAME response missing device type",
+    ):
+        SatelReadMessage.decode_frame(_frame_payload(payload))
+
+
+def test_decode_frame_returns_module_version_message() -> None:
+    payload = bytearray([0x7C]) + bytearray(b"12320120527") + bytearray([0b0000_0111])
+
+    msg = SatelReadMessage.decode_frame(_frame_payload(payload))
 
     assert isinstance(msg, SatelModuleVersionReadMessage)
     assert msg.module_info.firmware.version == "1.23"
@@ -115,6 +140,21 @@ def test_module_version_message_validates_payload_length(caplog) -> None:
         SatelModuleVersionReadMessage(SatelReadCommand.MODULE_VERSION, bytearray())
 
     assert "payload=" in caplog.text
+
+
+def test_zone_info_message_validates_payload_length(caplog) -> None:
+    with (
+        caplog.at_level(logging.WARNING),
+        pytest.raises(
+            SatelUnexpectedResponseError,
+            match="Invalid response length for READ_DEVICE_NAME",
+        ),
+    ):
+        SatelReadMessage.decode_frame(
+            _frame_payload(bytearray([0xEE, 0x05, 0x01, 0x2A]))
+        )
+
+    assert "payload=05012a" in caplog.text
 
 
 def test_integra_version_message_rejects_invalid_firmware_payload(caplog) -> None:

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -13,6 +13,7 @@ from satel_integra.messages import (
     SatelZoneInfoReadMessage,
     SatelZoneTemperatureReadMessage,
 )
+from satel_integra.models import SatelZoneInfo
 from satel_integra.utils import checksum
 
 
@@ -64,6 +65,30 @@ def test_decode_frame_returns_zone_info_message() -> None:
 
     assert isinstance(msg, SatelZoneInfoReadMessage)
     assert msg.msg_data == payload[1:]
+
+
+def test_read_message_parsed_property_is_cached(monkeypatch) -> None:
+    calls = 0
+    original_from_payload = SatelZoneInfo._from_payload
+
+    def from_payload(payload: bytes) -> SatelZoneInfo:
+        nonlocal calls
+        calls += 1
+        return original_from_payload(payload)
+
+    payload = (
+        bytearray([0x05, 0x01, 0x2A])
+        + bytearray(b"Front Door      ")
+        + bytearray([0x03])
+    )
+    msg = SatelZoneInfoReadMessage(SatelReadCommand.READ_DEVICE_NAME, payload)
+    monkeypatch.setattr(SatelZoneInfo, "_from_payload", from_payload)
+
+    first = msg.device_info
+    second = msg.device_info
+
+    assert first is second
+    assert calls == 1
 
 
 def test_decode_frame_returns_default_message_for_unknown_device_type(caplog) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,47 @@
+import pytest
+
+from satel_integra.models import SatelZoneInfo
+
+
+@pytest.mark.parametrize(
+    (
+        "zone_byte",
+        "name_payload",
+        "partition_assignment",
+        "expected_number",
+        "expected_name",
+        "expected_partition_assignment",
+    ),
+    [
+        (0x01, b"Front Door      ", 0x03, 1, "Front Door", 3),
+        (0x00, b"Top Floor       ", 0x00, 256, "Top Floor", None),
+        (
+            0x02,
+            b"Garage\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+            0x01,
+            2,
+            "Garage",
+            1,
+        ),
+    ],
+)
+def test_zone_info_from_payload(
+    zone_byte,
+    name_payload,
+    partition_assignment,
+    expected_number,
+    expected_name,
+    expected_partition_assignment,
+) -> None:
+    payload = (
+        bytearray([0x05, zone_byte, 0x2A])
+        + bytearray(name_payload)
+        + bytearray([partition_assignment])
+    )
+
+    zone_info = SatelZoneInfo._from_payload(payload)
+
+    assert zone_info.number == expected_number
+    assert zone_info.name == expected_name
+    assert zone_info.type_code == 0x2A
+    assert zone_info.partition_assignment == expected_partition_assignment

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -202,19 +202,18 @@ async def test_on_message_received_correct(mock_queue, write_msg, result_msg):
 
 
 @pytest.mark.asyncio
-async def test_on_message_received_commmand_mismatch(mock_queue, result_msg, caplog):
+async def test_on_message_received_completes_result_for_read_query(
+    mock_queue, result_msg, caplog
+):
     caplog.at_level(logging.WARNING)
 
     queued = QueuedMessage(SatelWriteMessage(SatelReadCommand.READ_DEVICE_NAME), True)
     mock_queue._current_message = queued
     mock_queue.on_message_received(result_msg)
 
-    assert (
-        "Received result ((SatelReadMessage) RESULT [0xEF] -> 01 (1)) for message ((SatelWriteMessage) READ_DEVICE_NAME [0xEE] ->  (0)) but expects different result (READ_DEVICE_NAME [0xEE])"
-        in caplog.text
-    )
-
-    assert not queued.processed_future.done()
+    assert "expects different result" in caplog.text
+    assert queued.processed_future.done()
+    assert queued.processed_future.result() is result_msg
 
 
 @pytest.mark.asyncio

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -410,6 +410,30 @@ async def test_read_zone_info_returns_none_without_response(satel, mock_queue):
 
 
 @pytest.mark.asyncio
+async def test_read_zone_info_returns_none_for_unavailable_zone_result(
+    satel, mock_queue
+):
+    mock_queue.add_message.return_value = SatelReadMessage(
+        SatelReadCommand.RESULT, bytearray([0x08])
+    )
+
+    result = await satel.read_zone_info(1)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_read_panel_info_returns_none_for_result_response(satel, mock_queue):
+    mock_queue.add_message.return_value = SatelReadMessage(
+        SatelReadCommand.RESULT, bytearray([0x08])
+    )
+
+    result = await satel.read_panel_info()
+
+    assert result is None
+
+
+@pytest.mark.asyncio
 async def test_read_zone_info_rejects_unexpected_response_type(satel, mock_queue):
     mock_queue.add_message.return_value = SatelReadMessage(
         SatelReadCommand.READ_DEVICE_NAME, bytearray([0x01])

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -16,6 +16,7 @@ from satel_integra.messages import (
     SatelIntegraVersionReadMessage,
     SatelModuleVersionReadMessage,
     SatelReadMessage,
+    SatelZoneInfoReadMessage,
     SatelZoneTemperatureReadMessage,
 )
 from satel_integra.satel_integra import AlarmState, AsyncSatel
@@ -242,6 +243,47 @@ async def test_read_temperatures_returns_expected_values(satel, side_effect, exp
 
 
 @pytest.mark.asyncio
+async def test_read_zone_info_returns_zone_info(satel, mock_queue):
+    response = SatelZoneInfoReadMessage(
+        SatelReadCommand.READ_DEVICE_NAME,
+        bytearray([0x05, 0x01, 0x2A])
+        + bytearray(b"Front Door      ")
+        + bytearray([0x03]),
+    )
+    mock_queue.add_message.return_value = response
+
+    result = await satel.read_zone_info(1)
+
+    assert isinstance(response, SatelZoneInfoReadMessage)
+    assert result == response.device_info
+
+    mock_queue.add_message.assert_awaited_once()
+    sent_msg = mock_queue.add_message.await_args.args[0]
+    assert sent_msg.cmd is SatelReadCommand.READ_DEVICE_NAME
+    assert sent_msg.msg_data == bytearray([0x05, 0x01])
+
+
+@pytest.mark.asyncio
+async def test_read_zone_info_encodes_zone_256_as_zero(satel, mock_queue):
+    response = SatelZoneInfoReadMessage(
+        SatelReadCommand.READ_DEVICE_NAME,
+        bytearray([0x05, 0x00, 0x2A])
+        + bytearray(b"Top Floor       ")
+        + bytearray([0x00]),
+    )
+    mock_queue.add_message.return_value = response
+
+    result = await satel.read_zone_info(256)
+
+    assert result is not None
+    assert result.number == 256
+    assert result.partition_assignment is None
+
+    sent_msg = mock_queue.add_message.await_args.args[0]
+    assert sent_msg.msg_data == bytearray([0x05, 0x00])
+
+
+@pytest.mark.asyncio
 async def test_read_panel_info_returns_panel_info(satel, mock_queue):
     response = SatelIntegraVersionReadMessage(
         SatelReadCommand.INTEGRA_VERSION,
@@ -350,6 +392,44 @@ async def test_read_temperature_rejects_unexpected_response_type(satel, mock_que
 
     with pytest.raises(SatelUnexpectedResponseError, match="Unexpected response type"):
         await satel.read_temperature(1)
+
+
+@pytest.mark.asyncio
+async def test_read_zone_info_rejects_invalid_zone(satel):
+    with pytest.raises(ValueError, match="zone_number must be between 1 and 256"):
+        await satel.read_zone_info(0)
+
+
+@pytest.mark.asyncio
+async def test_read_zone_info_returns_none_without_response(satel, mock_queue):
+    mock_queue.add_message.return_value = None
+
+    result = await satel.read_zone_info(1)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_read_zone_info_rejects_unexpected_response_type(satel, mock_queue):
+    mock_queue.add_message.return_value = SatelReadMessage(
+        SatelReadCommand.READ_DEVICE_NAME, bytearray([0x01])
+    )
+
+    with pytest.raises(SatelUnexpectedResponseError, match="Unexpected response type"):
+        await satel.read_zone_info(1)
+
+
+@pytest.mark.asyncio
+async def test_read_zone_info_rejects_zone_mismatch(satel, mock_queue):
+    mock_queue.add_message.return_value = SatelZoneInfoReadMessage(
+        SatelReadCommand.READ_DEVICE_NAME,
+        bytearray([0x05, 0x02, 0x2A])
+        + bytearray(b"Front Door      ")
+        + bytearray([0x03]),
+    )
+
+    with pytest.raises(ValueError, match="Zone info response zone mismatch"):
+        await satel.read_zone_info(1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Similar to https://github.com/c-soft/satel_integra/pull/62, adds the ability to read zone information from the panel. Useful to directly identify the zone names and types.