### PR TITLE
Change keepalive message

### DIFF
--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -313,9 +313,7 @@ class AsyncSatel:
                 )
                 continue
 
-            data = SatelWriteMessage(
-                SatelReadCommand.READ_DEVICE_NAME, raw_data=bytearray([0x01, 0x01])
-            )
+            data = SatelWriteMessage(SatelReadCommand.RTC_AND_STATUS)
             _LOGGER.debug(
                 "Keepalive sending after %.3fs of outbound inactivity", idle_for
             )

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -538,6 +538,25 @@ async def test_keepalive_loop_stops_when_connection_closes(
 
 
 @pytest.mark.asyncio
+async def test_keepalive_loop_sends_rtc_and_status_query(
+    satel, mock_connection, fake_sleep_factory
+):
+    fake_sleep_factory(
+        lambda sleep_count, _duration, _loop: (
+            setattr(mock_connection, "stopped", True) if sleep_count == 2 else None
+        )
+    )
+    satel._send_data_and_wait = AsyncMock(return_value=MagicMock())
+
+    await satel._keepalive_loop()
+
+    satel._send_data_and_wait.assert_called_once()
+    keepalive_message = satel._send_data_and_wait.await_args.args[0]
+    assert keepalive_message.cmd is SatelReadCommand.RTC_AND_STATUS
+    assert keepalive_message.msg_data == bytearray()
+
+
+@pytest.mark.asyncio
 async def test_keepalive_timeout_marks_same_connection_as_lost(
     satel, mock_connection, monkeypatch, caplog
 ):


### PR DESCRIPTION
We shouldn't use the Read Device Name command as keepalive message. If the alarm panel does not have the specific zone configured, it will respond with error RESULT messages instead. Even though they are now handled by [#63](https://github.com/c-soft/satel_integra/pull/63/changes#diff-bb925a5faa18957d2ae8babd3996719fd61dce459e95d8fd3c792b16793bb881R185-R186) and thus resolve the pending message, we will get debug logging every time a keepalive message is send.

This PR changes the keepalive message to a command that all panels will correctly respond to, as well as save a couple of bytes of transmitted data.
