### PR TITLE
Don't raise on unknown incoming commands

### DIFF
--- a/satel_integra/messages.py
+++ b/satel_integra/messages.py
@@ -176,6 +176,8 @@ class SatelReadMessage(SatelBaseMessage[SatelReadCommand]):
             )
             return None
 
+        _LOGGER.debug("Received command: %s", cmd)
+
         match cmd:
             case SatelReadCommand.MODULE_VERSION:
                 return SatelModuleVersionReadMessage(cmd, bytearray(data))

--- a/satel_integra/messages.py
+++ b/satel_integra/messages.py
@@ -143,7 +143,7 @@ class SatelReadMessage(SatelBaseMessage[SatelReadCommand]):
     @staticmethod
     def decode_frame(
         data: bytes,
-    ) -> "SatelReadMessage":
+    ) -> "SatelReadMessage | None":
         """Verify checksum and strip header/footer of received frame."""
         if data[0:2] != FRAME_START:
             _LOGGER.error("Bad header: %s", data.hex())
@@ -168,9 +168,13 @@ class SatelReadMessage(SatelBaseMessage[SatelReadCommand]):
         cmd_byte, data = output[0], output[1:-2]
         try:
             cmd = SatelReadCommand(cmd_byte)
-        except ValueError as ex:
-            _LOGGER.error("Unknown command byte: %s", hex(cmd_byte))
-            raise ValueError("Unknown command byte") from ex
+        except ValueError:
+            _LOGGER.warning(
+                "Ignoring unknown command byte: %s (payload=%s)",
+                hex(cmd_byte),
+                output.hex(),
+            )
+            return None
 
         match cmd:
             case SatelReadCommand.MODULE_VERSION:

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -646,7 +646,6 @@ class AsyncSatel:
                 return None
 
             msg = SatelReadMessage.decode_frame(data)
-            _LOGGER.debug("Received command: %s", msg)
             return msg
 
         except Exception as e:

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -116,6 +116,16 @@ def test_decode_frame_returns_default_message_for_unknown_device_type(caplog) ->
     assert "Unsupported READ_DEVICE_NAME device type: 0x06" in caplog.text
 
 
+def test_decode_frame_returns_none_for_unknown_command_byte(caplog) -> None:
+    payload = bytearray([0xAB, 0x01, 0x02, 0x03])
+
+    with caplog.at_level(logging.WARNING):
+        msg = SatelReadMessage.decode_frame(_frame_payload(payload))
+
+    assert msg is None
+    assert "Ignoring unknown command byte: 0xab" in caplog.text
+
+
 def test_decode_frame_rejects_missing_device_type() -> None:
     payload = bytearray([0xEE])
 


### PR DESCRIPTION
When messages with unknown (or not yet implemented) commands are read, the system would previously raise and let this error bubble up.

This PR changes that behavior, instead, now a warning message is logged and the rest of the message handling is skipped.
This will help with knowing which commands are missing (which can also be referred from the manual), but also which commands might be new or undocumented.

Related to https://github.com/home-assistant/core/issues/169738