### PR TITLE
Ignore Read Event messages

### DIFF
--- a/satel_integra/commands.py
+++ b/satel_integra/commands.py
@@ -36,6 +36,7 @@ class SatelReadCommand(SatelBaseCommand):
     MODULE_VERSION = 0x7C
     ZONE_TEMPERATURE = 0x7D
     INTEGRA_VERSION = 0x7E
+    READ_EVENT = 0x8C
     READ_DEVICE_NAME = 0xEE
     RESULT = 0xEF
 

--- a/satel_integra/messages.py
+++ b/satel_integra/messages.py
@@ -185,6 +185,12 @@ class SatelReadMessage(SatelBaseMessage[SatelReadCommand]):
                 return SatelZoneTemperatureReadMessage(cmd, bytearray(data))
             case SatelReadCommand.INTEGRA_VERSION:
                 return SatelIntegraVersionReadMessage(cmd, bytearray(data))
+            case SatelReadCommand.READ_EVENT:
+                _LOGGER.debug(
+                    "Received event message; event decoding is not implemented: %s",
+                    data.hex(),
+                )
+                return SatelReadMessage(cmd, bytearray(data))
             case SatelReadCommand.READ_DEVICE_NAME:
                 return _decode_device_read_message(cmd, bytearray(data))
             case _:

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -126,6 +126,19 @@ def test_decode_frame_returns_none_for_unknown_command_byte(caplog) -> None:
     assert "Ignoring unknown command byte: 0xab" in caplog.text
 
 
+def test_decode_frame_logs_event_messages_at_debug(caplog) -> None:
+    payload = bytearray.fromhex("8cbfc554c287fb0301035896035096")
+
+    with caplog.at_level(logging.DEBUG):
+        msg = SatelReadMessage.decode_frame(_frame_payload(payload))
+
+    assert type(msg) is SatelReadMessage
+    assert msg.cmd is SatelReadCommand.READ_EVENT
+    assert msg.msg_data == payload[1:]
+    assert "Received event message; event decoding is not implemented" in caplog.text
+    assert "Ignoring unknown command byte" not in caplog.text
+
+
 def test_decode_frame_rejects_missing_device_type() -> None:
     payload = bytearray([0xEE])
 


### PR DESCRIPTION
https://github.com/c-soft/satel_integra/pull/66 adjusted the message decoding so unknown command wouldn't raise.
This adjusts the process a bit more, actually defining the Read Event command and just ignoring it for now. Logging that one on warning level can cause a lot of noise, as some panel configurations do send out those events on specific actions (mainly user defined functions, like using a keyfob).