### PR TITLE
Add ability to read partition information

### DIFF
--- a/satel_integra/__init__.py
+++ b/satel_integra/__init__.py
@@ -18,6 +18,7 @@ from .models import (
     SatelOutputInfo,
     SatelPanelInfo,
     SatelPanelModel,
+    SatelPartitionInfo,
     SatelZoneInfo,
 )
 from .satel_integra import AlarmState, AsyncSatel
@@ -39,6 +40,7 @@ __all__ = [
     "SatelPanelBusyError",
     "SatelPanelInfo",
     "SatelPanelModel",
+    "SatelPartitionInfo",
     "SatelUnexpectedResponseError",
     "SatelZoneInfo",
 ]

--- a/satel_integra/messages.py
+++ b/satel_integra/messages.py
@@ -24,6 +24,7 @@ from satel_integra.models import (
     SatelCommunicationModuleInfo,
     SatelOutputInfo,
     SatelPanelInfo,
+    SatelPartitionInfo,
     SatelZoneInfo,
 )
 from satel_integra.utils import (
@@ -46,6 +47,7 @@ class SatelDeviceSelector(IntEnum):
 
     OUTPUT = 0x04
     ZONE_WITH_PARTITION_ASSIGNMENT = 0x05
+    PARTITION_WITH_OBJECT_ASSIGNMENT = 0x10
 
 
 def _decode_device_read_message(
@@ -58,6 +60,8 @@ def _decode_device_read_message(
         )
 
     match msg_data[0]:
+        case SatelDeviceSelector.PARTITION_WITH_OBJECT_ASSIGNMENT:
+            return SatelPartitionInfoReadMessage(cmd, msg_data)
         case SatelDeviceSelector.OUTPUT:
             return SatelOutputInfoReadMessage(cmd, msg_data)
         case SatelDeviceSelector.ZONE_WITH_PARTITION_ASSIGNMENT:
@@ -252,6 +256,17 @@ class SatelZoneInfoReadMessage(SatelReadMessage):
     def device_info(self) -> SatelZoneInfo:
         """Return parsed zone information."""
         return SatelZoneInfo._from_payload(self.msg_data)
+
+
+class SatelPartitionInfoReadMessage(SatelReadMessage):
+    """Structured read message for a 0xEE partition info response."""
+
+    expected_data_length = 20
+
+    @cached_property
+    def device_info(self) -> SatelPartitionInfo:
+        """Return parsed partition information."""
+        return SatelPartitionInfo._from_payload(self.msg_data)
 
 
 class SatelOutputInfoReadMessage(SatelReadMessage):

--- a/satel_integra/models/__init__.py
+++ b/satel_integra/models/__init__.py
@@ -5,6 +5,7 @@ from .firmware import SatelFirmwareVersion
 from .module import SatelCommunicationModuleInfo
 from .output import SatelOutputInfo
 from .panel import SatelPanelInfo, SatelPanelModel
+from .partition import SatelPartitionInfo
 from .zone import SatelZoneInfo
 
 __all__ = [
@@ -15,5 +16,6 @@ __all__ = [
     "SatelOutputInfo",
     "SatelPanelInfo",
     "SatelPanelModel",
+    "SatelPartitionInfo",
     "SatelZoneInfo",
 ]

--- a/satel_integra/models/device.py
+++ b/satel_integra/models/device.py
@@ -8,6 +8,7 @@ from enum import Enum, unique
 class SatelDeviceType(Enum):
     """Semantic device types returned by 0xEE reads."""
 
+    PARTITION = "partition"
     OUTPUT = "output"
     ZONE = "zone"
 

--- a/satel_integra/models/partition.py
+++ b/satel_integra/models/partition.py
@@ -1,0 +1,22 @@
+"""Structured partition information."""
+
+from dataclasses import dataclass, field
+
+from .device import SatelDeviceInfo, SatelDeviceType
+
+
+@dataclass(frozen=True)
+class SatelPartitionInfo(SatelDeviceInfo):
+    """Information returned by the 0xEE partition name read command."""
+
+    device_type: SatelDeviceType = field(default=SatelDeviceType.PARTITION, init=False)
+    type_code: int
+
+    @classmethod
+    def _from_payload(cls, payload: bytes) -> "SatelPartitionInfo":
+        """Parse a 0xEE partition payload."""
+        return cls(
+            device_number=payload[1],
+            name=cls._decode_name(payload),
+            type_code=payload[2],
+        )

--- a/satel_integra/models/partition.py
+++ b/satel_integra/models/partition.py
@@ -7,16 +7,18 @@ from .device import SatelDeviceInfo, SatelDeviceType
 
 @dataclass(frozen=True)
 class SatelPartitionInfo(SatelDeviceInfo):
-    """Information returned by the 0xEE partition name read command."""
+    """Information returned by the 0xEE partition read command."""
 
     device_type: SatelDeviceType = field(default=SatelDeviceType.PARTITION, init=False)
     type_code: int
+    object_assignment: int | None
 
     @classmethod
     def _from_payload(cls, payload: bytes) -> "SatelPartitionInfo":
-        """Parse a 0xEE partition payload."""
+        """Parse a 0xEE partition payload with object assignment."""
         return cls(
             device_number=payload[1],
             name=cls._decode_name(payload),
             type_code=payload[2],
+            object_assignment=payload[19] if payload[19] else None,
         )

--- a/satel_integra/satel_integra.py
+++ b/satel_integra/satel_integra.py
@@ -23,6 +23,7 @@ from satel_integra.messages import (
     SatelIntegraVersionReadMessage,
     SatelModuleVersionReadMessage,
     SatelOutputInfoReadMessage,
+    SatelPartitionInfoReadMessage,
     SatelReadMessage,
     SatelWriteMessage,
     SatelZoneInfoReadMessage,
@@ -32,6 +33,7 @@ from satel_integra.models import (
     SatelCommunicationModuleInfo,
     SatelOutputInfo,
     SatelPanelInfo,
+    SatelPartitionInfo,
     SatelZoneInfo,
 )
 from satel_integra.queue import SatelMessageQueue
@@ -541,6 +543,34 @@ class AsyncSatel:
             msg = (
                 "Zone info response zone mismatch: "
                 f"expected {zone_id}, got {response.device_info.device_number}"
+            )
+            raise ValueError(msg)
+
+        return response.device_info
+
+    async def read_partition_info(self, partition_id: int) -> SatelPartitionInfo | None:
+        """Read metadata for a single partition."""
+        if not 1 <= partition_id <= 32:
+            raise ValueError("partition_id must be between 1 and 32")
+
+        msg = SatelWriteMessage(
+            SatelReadCommand.READ_DEVICE_NAME,
+            raw_data=bytearray(
+                [SatelDeviceSelector.PARTITION_WITH_OBJECT_ASSIGNMENT, partition_id]
+            ),
+        )
+        response = await self._typed_send_data_and_wait(
+            msg,
+            SatelPartitionInfoReadMessage,
+        )
+
+        if response is None:
+            return None
+
+        if response.device_info.device_number != partition_id:
+            msg = (
+                "Partition info response partition mismatch: "
+                f"expected {partition_id}, got {response.device_info.device_number}"
             )
             raise ValueError(msg)
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -9,6 +9,7 @@ from satel_integra.messages import (
     SatelIntegraVersionReadMessage,
     SatelModuleVersionReadMessage,
     SatelOutputInfoReadMessage,
+    SatelPartitionInfoReadMessage,
     SatelReadMessage,
     SatelWriteMessage,
     SatelZoneInfoReadMessage,
@@ -66,6 +67,23 @@ def test_decode_frame_returns_zone_info_message() -> None:
 
     assert isinstance(msg, SatelZoneInfoReadMessage)
     assert msg.msg_data == payload[1:]
+
+
+def test_decode_frame_returns_partition_info_message() -> None:
+    payload = (
+        bytearray([0xEE, 0x10, 0x01, 0x03])
+        + bytearray(b"Ground Floor    ")
+        + bytearray([0x02])
+    )
+
+    msg = SatelReadMessage.decode_frame(_frame_payload(payload))
+
+    assert isinstance(msg, SatelPartitionInfoReadMessage)
+    assert msg.msg_data == payload[1:]
+    assert msg.device_info.device_number == 1
+    assert msg.device_info.name == "Ground Floor"
+    assert msg.device_info.type_code == 0x03
+    assert msg.device_info.object_assignment == 2
 
 
 def test_decode_frame_returns_output_info_message() -> None:
@@ -208,6 +226,21 @@ def test_output_info_message_validates_payload_length(caplog) -> None:
         )
 
     assert "payload=040110" in caplog.text
+
+
+def test_partition_info_message_validates_payload_length(caplog) -> None:
+    with (
+        caplog.at_level(logging.WARNING),
+        pytest.raises(
+            SatelUnexpectedResponseError,
+            match="Invalid response length for READ_DEVICE_NAME",
+        ),
+    ):
+        SatelReadMessage.decode_frame(
+            _frame_payload(bytearray([0xEE, 0x10, 0x01, 0x03]))
+        )
+
+    assert "payload=100103" in caplog.text
 
 
 def test_integra_version_message_rejects_invalid_firmware_payload(caplog) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,56 @@
 import pytest
 
-from satel_integra.models import SatelDeviceType, SatelOutputInfo, SatelZoneInfo
+from satel_integra.models import (
+    SatelDeviceType,
+    SatelOutputInfo,
+    SatelPartitionInfo,
+    SatelZoneInfo,
+)
+
+
+@pytest.mark.parametrize(
+    (
+        "partition_byte",
+        "name_payload",
+        "object_assignment",
+        "expected_number",
+        "expected_name",
+        "expected_object_assignment",
+    ),
+    [
+        (0x01, b"Ground Floor    ", 0x02, 1, "Ground Floor", 2),
+        (0x20, b"Guest Wing      ", 0x08, 32, "Guest Wing", 8),
+        (
+            0x02,
+            b"Night\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+            0x00,
+            2,
+            "Night",
+            None,
+        ),
+    ],
+)
+def test_partition_info_from_payload(
+    partition_byte,
+    name_payload,
+    object_assignment,
+    expected_number,
+    expected_name,
+    expected_object_assignment,
+) -> None:
+    payload = (
+        bytearray([0x10, partition_byte, 0x03])
+        + bytearray(name_payload)
+        + bytearray([object_assignment])
+    )
+
+    partition_info = SatelPartitionInfo._from_payload(payload)
+
+    assert partition_info.device_type is SatelDeviceType.PARTITION
+    assert partition_info.device_number == expected_number
+    assert partition_info.name == expected_name
+    assert partition_info.type_code == 0x03
+    assert partition_info.object_assignment == expected_object_assignment
 
 
 @pytest.mark.parametrize(

--- a/tests/test_satel_integra.py
+++ b/tests/test_satel_integra.py
@@ -16,10 +16,12 @@ from satel_integra.messages import (
     SatelIntegraVersionReadMessage,
     SatelModuleVersionReadMessage,
     SatelOutputInfoReadMessage,
+    SatelPartitionInfoReadMessage,
     SatelReadMessage,
     SatelZoneInfoReadMessage,
     SatelZoneTemperatureReadMessage,
 )
+from satel_integra.models import SatelPartitionInfo
 from satel_integra.satel_integra import AlarmState, AsyncSatel
 
 
@@ -265,6 +267,27 @@ async def test_read_zone_info_returns_zone_info(satel, mock_queue):
 
 
 @pytest.mark.asyncio
+async def test_read_partition_info_returns_partition_info(satel, mock_queue):
+    response = SatelPartitionInfoReadMessage(
+        SatelReadCommand.READ_DEVICE_NAME,
+        bytearray([0x10, 0x01, 0x03])
+        + bytearray(b"Ground Floor    ")
+        + bytearray([0x02]),
+    )
+    mock_queue.add_message.return_value = response
+
+    result = await satel.read_partition_info(1)
+
+    assert isinstance(result, SatelPartitionInfo)
+    assert result == response.device_info
+
+    mock_queue.add_message.assert_awaited_once()
+    sent_msg = mock_queue.add_message.await_args.args[0]
+    assert sent_msg.cmd is SatelReadCommand.READ_DEVICE_NAME
+    assert sent_msg.msg_data == bytearray([0x10, 0x01])
+
+
+@pytest.mark.asyncio
 async def test_read_zone_info_encodes_zone_256_as_zero(satel, mock_queue):
     response = SatelZoneInfoReadMessage(
         SatelReadCommand.READ_DEVICE_NAME,
@@ -318,6 +341,15 @@ async def test_read_output_info_encodes_output_256_as_zero(satel, mock_queue):
 
     sent_msg = mock_queue.add_message.await_args.args[0]
     assert sent_msg.msg_data == bytearray([0x04, 0x00])
+
+
+@pytest.mark.asyncio
+async def test_read_partition_info_returns_none_without_response(satel, mock_queue):
+    mock_queue.add_message.return_value = None
+
+    result = await satel.read_partition_info(1)
+
+    assert result is None
 
 
 @pytest.mark.asyncio
@@ -458,6 +490,19 @@ async def test_read_output_info_returns_none_without_response(satel, mock_queue)
 
 
 @pytest.mark.asyncio
+async def test_read_partition_info_returns_none_for_unavailable_partition_result(
+    satel, mock_queue
+):
+    mock_queue.add_message.return_value = SatelReadMessage(
+        SatelReadCommand.RESULT, bytearray([0x08])
+    )
+
+    result = await satel.read_partition_info(1)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
 async def test_read_zone_info_returns_none_for_unavailable_zone_result(
     satel, mock_queue
 ):
@@ -515,6 +560,16 @@ async def test_read_output_info_rejects_unexpected_response_type(satel, mock_que
 
 
 @pytest.mark.asyncio
+async def test_read_partition_info_rejects_unexpected_response_type(satel, mock_queue):
+    mock_queue.add_message.return_value = SatelReadMessage(
+        SatelReadCommand.READ_DEVICE_NAME, bytearray([0x01])
+    )
+
+    with pytest.raises(SatelUnexpectedResponseError, match="Unexpected response type"):
+        await satel.read_partition_info(1)
+
+
+@pytest.mark.asyncio
 async def test_read_zone_info_rejects_zone_mismatch(satel, mock_queue):
     mock_queue.add_message.return_value = SatelZoneInfoReadMessage(
         SatelReadCommand.READ_DEVICE_NAME,
@@ -536,6 +591,28 @@ async def test_read_output_info_rejects_output_mismatch(satel, mock_queue):
 
     with pytest.raises(ValueError, match="Output info response output mismatch"):
         await satel.read_output_info(1)
+
+
+@pytest.mark.asyncio
+async def test_read_partition_info_rejects_partition_mismatch(satel, mock_queue):
+    mock_queue.add_message.return_value = SatelPartitionInfoReadMessage(
+        SatelReadCommand.READ_DEVICE_NAME,
+        bytearray([0x10, 0x02, 0x03])
+        + bytearray(b"Ground Floor    ")
+        + bytearray([0x02]),
+    )
+
+    with pytest.raises(ValueError, match="Partition info response partition mismatch"):
+        await satel.read_partition_info(1)
+
+
+@pytest.mark.asyncio
+async def test_read_partition_info_rejects_invalid_partition_number(satel) -> None:
+    with pytest.raises(ValueError, match="partition_id must be between 1 and 32"):
+        await satel.read_partition_info(0)
+
+    with pytest.raises(ValueError, match="partition_id must be between 1 and 32"):
+        await satel.read_partition_info(33)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Similar to #62, #63 and #64, adds the ability to read partition information from the panel. Useful to directly identify the partition zone names and types.