### PR TITLE
Change firmware release_date type to string

### DIFF
--- a/satel_integra/models/firmware.py
+++ b/satel_integra/models/firmware.py
@@ -2,7 +2,6 @@
 
 import logging
 from dataclasses import dataclass
-from datetime import date
 
 from satel_integra.exceptions import SatelUnexpectedResponseError
 
@@ -14,7 +13,7 @@ class SatelFirmwareVersion:
     """Firmware version parsed from the Satel protocol version payload."""
 
     version: str
-    release_date: date
+    release_date: str
 
     @classmethod
     def _from_payload(cls, payload: bytes) -> "SatelFirmwareVersion":
@@ -32,15 +31,6 @@ class SatelFirmwareVersion:
             raise SatelUnexpectedResponseError(msg)
 
         version = f"{int(raw_version[0])}.{int(raw_version[1:3]):02d}"
-        try:
-            release_date = date(
-                int(raw_version[3:7]),
-                int(raw_version[7:9]),
-                int(raw_version[9:11]),
-            )
-        except ValueError as err:
-            msg = f"Invalid firmware release date payload: {raw_version!r}"
-            _LOGGER.warning(msg)
-            raise SatelUnexpectedResponseError(msg) from err
+        release_date = f"{raw_version[3:7]}-{raw_version[7:9]}-{raw_version[9:11]}"
 
         return cls(version=version, release_date=release_date)

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import date
 
 import pytest
 
@@ -67,7 +66,7 @@ def _invalid_payload_for_lengths(
             SatelPanelInfo(
                 type_code=72,
                 model=SatelPanelModel("INTEGRA 256 Plus"),
-                firmware=SatelFirmwareVersion("1.23", date(2012, 5, 27)),
+                firmware=SatelFirmwareVersion("1.23", "2012-05-27"),
                 language_code=0,
                 settings_stored_in_flash=True,
             ),
@@ -112,7 +111,7 @@ def _invalid_payload_for_lengths(
             + bytearray([0b0000_0111]),
             SatelModuleVersionReadMessage,
             SatelCommunicationModuleInfo(
-                firmware=SatelFirmwareVersion("1.23", date(2012, 5, 27)),
+                firmware=SatelFirmwareVersion("1.23", "2012-05-27"),
                 supports_256_zones_outputs=True,
                 supports_trouble_memory_part_8=True,
                 supports_arm_no_bypass=True,


### PR DESCRIPTION
Changes the release_date property of firmware models to be a str. This doesn't need to be a date, we don't need any validation on it actually being a valid date or not, we just trust the data we get.