### PR TITLE
Add str representation to firmware

### DIFF
--- a/satel_integra/models/firmware.py
+++ b/satel_integra/models/firmware.py
@@ -15,6 +15,10 @@ class SatelFirmwareVersion:
     version: str
     release_date: str
 
+    def __str__(self) -> str:
+        """Return a display-friendly firmware version."""
+        return f"{self.version} ({self.release_date})"
+
     @classmethod
     def _from_payload(cls, payload: bytes) -> "SatelFirmwareVersion":
         """Parse an 11-byte Satel firmware payload like b'12320120527'."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,6 +2,7 @@ import pytest
 
 from satel_integra.models import (
     SatelDeviceType,
+    SatelFirmwareVersion,
     SatelOutputInfo,
     SatelPartitionInfo,
     SatelZoneInfo,
@@ -129,3 +130,9 @@ def test_output_info_from_payload(
     assert output_info.device_number == expected_number
     assert output_info.name == expected_name
     assert output_info.type_code == 0x10
+
+
+def test_firmware_version_formats_as_string() -> None:
+    firmware = SatelFirmwareVersion("1.23", "2025-05-15")
+
+    assert str(firmware) == "1.23 (2025-05-15)"


### PR DESCRIPTION
Added a small method to get unified firmware version representations when firmware class is cast to string. The format follows the example on the protocol spec datasheet. 